### PR TITLE
v0.3.0: Direct-Ipopt primal solvers (default for Armington cases)

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,31 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`OptimalTransportNetworks.jl` is a Julia package implementing the quantitative spatial economic model of Fajgelbaum & Schaal (2020, *Econometrica*): it computes the welfare-maximizing transport network on a graph given economic fundamentals (population, productivity per good, housing endowment, optional pre-existing network). It is a JuMP-based translation of the authors' MATLAB `OptimalTransportNetworkToolbox` (v1.0.4b). The reference MATLAB code lives under `misc/matlab/` and is the source of truth when porting or debugging numerical behavior.
+
+## Commands
+
+This is a registered Julia package. From the repo root, start Julia with `julia --project=.` (or `julia --project=examples` to use the examples environment, which adds Revise, BenchmarkTools, GR, Optim, etc.).
+
+```julia
+# Develop / load the package
+using Pkg; Pkg.instantiate()        # first time, installs deps from Manifest.toml
+using OptimalTransportNetworks       # package is the project
+
+# Iterate on source without restarting (examples env has Revise)
+using Revise, OptimalTransportNetworks
+```
+
+- **Run an example:** `julia --project=examples examples/example01.jl` (examples `01`–`04` are tutorials; `paper_example01`–`04` reproduce paper figures).
+- **Build docs:** `julia --project=docs docs/make.jl` (Documenter.jl; output in `docs/build/`).
+- **Tests:** there is **no `test/` suite**. The examples serve as the de-facto integration tests — run them to verify changes end-to-end. The package builds figures, so verify by inspecting plots / `results[:welfare]`, not by assertions.
+
+## Core data model
+
+Two user-facing containers, both plain `Dict{Symbol,Any}` while the user edits them, converted internally to `NamedTuple` (`dict_to_namedtuple` in `src/main/helper.jl`):
+
+- **`param`** (from `init_parameters`): non-spatial model parameters only — `alpha, beta, gamma, sigma, rho, a, K`, the `mobility`/`cong` switches, solver options, and closures for utility/production functions.
+- **`graph`** (from `create_graph`): both the graph topology **and** all spatial data — `J` (nodes), `nodes`/`adjacency`, `delta_i` (build cost) / `delta_tau` (traversal cost) per edge, and spatial parameters `Zjn` (productivity J×N), `Lj`/`Lr` (labor), `Hj`/`hj` (housing), `omegaj`. Note: as of v0.1.6 all spatial parameters live in `graph`, not `param` (see `NEWS.md`).
+
+`apply_geography` optionally rescales `delta_i`/`delta_tau` for terrain/obstacles.
+
+## Solver pipeline (the big picture)
+
+`optimal_network(param, graph)` in `src/main/optimal_network.jl` is the entry point. It solves the **outer** network-design problem by fixed-point iteration over infrastructure `I`, each iteration solving the **inner** allocation (general-equilibrium trade) problem:
+
+1. Convert dicts → NamedTuples; `represent_edges(graph)` builds the edge incidence representation (`A`, `Apos`, `Aneg`, `edge_start`, `edge_end`).
+2. `create_auxdata(param, graph, edges, I)` computes `kappa = I^gamma / delta_tau` (edge capacities) and the reduced `kappa_ex` vector.
+3. `get_model(auxdata)` **dispatches** to one of the inner-problem solvers (see below), returning `(model, recover_allocation)`.
+4. Loop: solve inner problem → from prices×flows compute the FOC-optimal `I1` → rescale to budget `K` and bounds (`rescale_network!`) → damped update `I0 = 0.5*I0 + 0.5*I1` → push new `kappa` into the model. Repeat until `max|I1-I0|/K_infra < tol`.
+5. If `gamma > beta` and `param.annealing`, refine the (non-convex) solution via `annealing` (`src/main/annealing.jl`, simulated annealing over network topology).
+
+Returns a `Dict` keyed by symbols; always includes at least `:welfare`, `:Pjn`, `:PCj`, `:Qjkn`, and `:Ijk` (the optimal network).
+
+### Model dispatch (`get_model` in `src/main/helper.jl`)
+
+This is the most important thing to understand before touching `src/models/`. The inner solver is selected by the cross product of three switches:
+
+- **`param.mobility`** ∈ `{0, 0.5, 1}` (fixed / partial / full labor mobility)
+- **`param.cong`** (cross-good congestion on/off)
+- **Armington vs. general:** auto-detected — `armington = all(sum(graph.Zjn .> 0, dims=2) .<= 1)`, i.e. every node produces ≤1 good.
+
+**Default path is now direct Ipopt for Armington cases.** As of v0.3.0, every Armington primal case is solved by a hand-coded `solve_allocation_*` function that calls **Ipopt's C interface directly** (like the dual solvers), returning `model = nothing` so `optimal_network` takes the `model === nothing` branch. These are faster than JuMP. The files: `solve_allocation_mobility(_cgc)`, `solve_allocation_partial_mobility(_cgc)`, `solve_allocation_cgc`, `solve_allocation_primal` — one per `(mobility × cong)` (the fixed-labor, no-cong, `beta≤1` case stays on the even-faster dual). They share `src/models/solve_allocation_primal_helpers.jl` (`run_ipopt_primal`, sparse-structure + value scatter via `struct_from_triplets`/`fill_values_from_triplets!`, and the `felicity*` Cobb-Douglas helpers).
+
+**JuMP is the fallback**, taken when `param.jump == true` **or** the input is **non-Armington** (a node produces ≥2 goods, which the hand-coded solvers don't support). Then `get_model` builds the matching `model_*` JuMP model (general `model_*` for multi-good-per-node, `*_armington` when `param.jump` forces JuMP on an Armington input). Naming encodes the switches, e.g. `model_partial_mobility_cgc_armington.jl`.
+
+**Special case — duality:** when `mobility == 0` and `beta <= 1` and `param.duality > 0`, `get_model` dispatches to `solve_allocation_by_duality` (or `..._cgc`) — hard-coded sparse gradient/Hessian, the fastest path, handling both Armington and general. This takes precedence over the direct-primal and JuMP branches.
+
+**Direct-solver conventions** (see `git log` / `misc/matlab/solve_allocation_*.m`): full mobility & all cgc cases use **split** directional flows `Qin_direct`/`Qin_indirect`; partial mobility & the fixed primal use a **single signed** `Qin` (split flows find worse local optima in non-convex partial mobility). Each `solve_allocation_*(x0, auxdata, verbose) -> (Dict, status, x)`; prices come from the balanced-flow constraint multipliers (`prob.mult_g`). Validate any change with a finite-difference check of the hand-coded Jacobian/Hessian at a random interior point (Ipopt's `derivative_test` gives false positives at the degenerate `x0=1e-6`).
+
+**Problem reuse (perf).** `optimal_network` threads a per-run `struct_cache::Dict` through `auxdata`. The direct solvers compute their sparsity structure once (`get_structs`/`struct_from_triplets` build a column-major pattern + a linear-index→position map; values are *scattered* into the Ipopt buffers via `fill_values_from_triplets!` — never build a `sparse()` inside a callback, it corrupts the heap), then `run_ipopt_primal` caches the Ipopt problem object keyed by solver and **reuses it across outer iterations**, re-solving warm-started after updating `kappa_ex` in place in the callbacks' captured `saux`. This (plus analytic derivatives) makes the direct path several× to ~60× faster than JuMP at realistic sizes. Annealing builds its own `auxdata` without the cache, so it falls back to per-call construction (correct, just not reused).
+
+**Environment:** the bundled MUMPS/OpenBLAS in old `Ipopt_jll` (pre-Julia-1.12 Manifests) segfaults on larger problems — keep the Manifest resolved for the running Julia (Ipopt ≥ 1.15 / OpenBLAS ≥ 0.3.33).
+
+**Custom models:** users may pass `param[:model]` and `param[:recover_allocation]` to override dispatch entirely.
+
+## Directory map
+
+- `src/main/` — pipeline: `optimal_network.jl`, `annealing.jl`, `create_graph.jl`, `init_parameters.jl`, `apply_geography.jl`, `nodes.jl` (`find_node`/`add_node`/`remove_node`), `plot_graph.jl`, `helper.jl` (dispatch + edge/auxdata machinery).
+- `src/models/` — the ~16 `model_*` builders + their `recover_allocation_*` functions, plus the two `solve_allocation_by_duality*` direct-Ipopt solvers.
+- `src/OptimalTransportNetworks.jl` — module; auto-includes every `.jl` under `main/` then `models/` via `include_directory`, and lists the exports.
+- `examples/` — runnable tutorials and paper reproductions.
+- `misc/` — MATLAB reference (`misc/matlab/`), experiments, LaTeX derivations of the duality solution (`misc/duality_*`), figures. Untracked scratch; not part of the package.
+
+## Conventions & gotchas
+
+- Adding a source file: just drop it in `src/main/` or `src/models/` — `include_directory` picks up all `.jl` automatically; no manual `include` needed. Add new public functions to the `export` list in `src/OptimalTransportNetworks.jl`.
+- The graph is undirected; edges are stored once with `nodes[j][k] > j` guarding the canonical direction (see `represent_edges`, `kappa_extract`). Respect this when iterating edges.
+- `recover_allocation` for any new/custom model **must** return a Dict including `:welfare`, `:Pjn`, `:PCj`, `:Qjkn` — `optimal_network` reads these to compute the next `I`.
+- Convexity guards live at the top of `optimal_network`: `a > 1` and (`nu < 1` with congestion) error out; non-convex cases (`gamma > beta`) are where annealing matters.
+- For performance, the README documents enabling Coin-HSL linear solvers via `param[:optimizer_attr]` and MathOptSymbolicAD via `param[:model_attr]`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# 0.3.0
+
+* **Direct-Ipopt primal solvers are now the default for Armington cases (≤1 good per location).** Previously only the dual cases (fixed labor, `beta <= 1`) bypassed JuMP. Now every Armington primal case is solved by a hand-coded `solve_allocation_*` function that calls Ipopt's C interface directly (like the dual solvers), with analytic sparse gradients/Jacobians/Hessians — faster than JuMP. New solvers: `solve_allocation_mobility(_cgc)`, `solve_allocation_partial_mobility(_cgc)`, `solve_allocation_cgc`, `solve_allocation_primal` (fixed labor, `beta > 1`).
+
+* **JuMP is now an opt-in fallback.** Pass `jump = true` to `init_parameters` to force the JuMP path. The general (non-Armington, multi-good-per-location) case still always uses JuMP.
+
+* Fixed a latent bug in `init_parameters`: the utility-function closures (`u`, `uprime`, `usecond`) captured `rho` before it was zeroed for full labor mobility, so they used `rho` instead of `0` in the mobile-labor case. This only affected reported per-location utility `uj` (not welfare).
+
+* **Performance.** The direct solvers reuse their Ipopt problem object across the outer (network) iterations — building the sparsity structure and the problem once, then re-solving warm-started (primal *and* dual) with only the updated `kappa`, exactly as the JuMP path reuses its model. Combined with the analytic derivatives this makes them faster than JuMP across all cases at realistic sizes — e.g. on an 81-node graph (30 fixed iterations): full mobility ~3.8×, fixed-labor `beta>1` ~9×, partial mobility ~10×, fixed cgc ~15×, mobility+cgc ~64×; the gap widens with graph size. The smallest non-cgc problems are at rough parity with JuMP.
+
+* **Manifest regenerated for Julia ≥ 1.12.** The previous `Manifest.toml` was generated under Julia 1.8.5 and pinned old `Ipopt_jll`/`OpenBLAS` binaries (`libopenblas 0.3.17`) that segfault on larger problems under newer Julia — affecting the JuMP path too. The Manifest now resolves Ipopt 1.15 / OpenBLAS 0.3.33, which fixes the crashes. Coin-HSL `ma57`/`ma86` (see README) remain recommended for the best performance: `param[:optimizer_attr] = Dict(:hsllib => HSL_jll.libhsl_path, :linear_solver => "ma57")`.
+
 # 0.2.0
 
 * The reason for the less than ideal numerical properties of the exact dual solution for the Hessian with `cross_good_congestion = true` in v0.1.9 was that the sparse hessian had too few elements. This release fixes the problem by adding some additional off-diagonal elements to the sparse hesssian. The heuristic algorithm is now removed as the exact one always gives better solves (`duality = true` and `duality = 2` both call the exact algorithm now). 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransportNetworks"
 uuid = "e2b46e68-897f-4e4e-ba36-a93c9789fd96"
 authors = ["Sebastian Krantz <sebastian.krantz@graduateinstitute.ch>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ This plot shows the optimal network after 200 iterations, keeping population fix
 
 ## Performance Notes
 
-* The Julia implementation for the most part does not provide hard-coded Gradients, Jacobians, and Hessians as the MATLAB implementation does for some model cases, but relies solely on JuMP's automatic differentiation. One exception is dual solutions which are implemented directly using Ipopt and hard-coded sparse Hessians - they are super fast. By default `duality = true`, and if labor is fixed and `beta <= 1`, users will experience very fast dual solves. I also expect non-dual solutions to speed up when [support for detecting nonlinear subexpressions](https://github.com/jump-dev/JuMP.jl/issues/3738) will be added to JuMP.  
+* As of v0.3.0, the default solver path calls [Ipopt](https://github.com/jump-dev/Ipopt.jl) directly (via its C interface) with hard-coded sparse gradients, Jacobians, and Hessians — like the original MATLAB toolbox — for **all Armington cases** (at most one good produced per location), across fixed / partial / full labor mobility, with or without cross-good congestion. The Ipopt problem is built once and reused (warm-started) across the network-design iterations. This is several times to an order of magnitude faster than the JuMP path at realistic graph sizes, and the gap widens as the graph grows. The fixed-labor, `beta <= 1` case additionally uses the even-faster **dual** solution (`duality = true` by default).
+
+* JuMP (and its automatic differentiation) is now an opt-in fallback: set `jump = true` in `init_parameters` to force it. The general, non-Armington case (a location producing two or more goods) is not covered by the hand-coded solvers and always uses JuMP, regardless of the `jump` switch.
 
 * Symbolic autodifferentiation via [MathOptSymbolicAD.jl](https://github.com/lanl-ansi/MathOptSymbolicAD.jl) can also provide significant performance improvements for non-dual cases. The symbolic backend can be activated using:
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,2 @@
 [deps]
-Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OptimalTransportNetworks = "e2b46e68-897f-4e4e-ba36-a93c9789fd96"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,7 +26,9 @@ This plot shows the optimal network after 200 iterations, keeping population fix
 
 ## Performance Notes
 
-* The Julia implementation for the most part does not provide hard-coded Gradients, Jacobians, and Hessians as the MATLAB implementation does for some model cases, but relies solely on JuMP's automatic differentiation. One exception is dual solutions which are implemented directly using Ipopt and hard-coded sparse Hessians - they are super fast. By default `duality = true`, and if labor is fixed and `beta <= 1`, users will experience very fast dual solves. I also expect non-dual solutions to speed up when [support for detecting nonlinear subexpressions](https://github.com/jump-dev/JuMP.jl/issues/3738) will be added to JuMP.  
+* As of v0.3.0, the default solver path calls [Ipopt](https://github.com/jump-dev/Ipopt.jl) directly (via its C interface) with hard-coded sparse gradients, Jacobians, and Hessians — like the original MATLAB toolbox — for **all Armington cases** (at most one good produced per location), across fixed / partial / full labor mobility, with or without cross-good congestion. The Ipopt problem is built once and reused (warm-started) across the network-design iterations. This is several times to an order of magnitude faster than the JuMP path at realistic graph sizes, and the gap widens as the graph grows. The fixed-labor, `beta <= 1` case additionally uses the even-faster **dual** solution (`duality = true` by default).
+
+* JuMP (and its automatic differentiation) is now an opt-in fallback: set `jump = true` in `init_parameters` to force it. The general, non-Armington case (a location producing two or more goods) is not covered by the hand-coded solvers and always uses JuMP, regardless of the `jump` switch.
 
 * Symbolic autodifferentiation via [MathOptSymbolicAD.jl](https://github.com/lanl-ansi/MathOptSymbolicAD.jl) can also provide significant performance improvements for non-dual cases. The symbolic backend can be activated using:
 

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+OptimalTransportNetworks = "e2b46e68-897f-4e4e-ba36-a93c9789fd96"
+PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/src/main/helper.jl
+++ b/src/main/helper.jl
@@ -221,6 +221,11 @@ function get_model(auxdata)
      graph = auxdata.graph
      optimizer = get(param, :optimizer, Ipopt.Optimizer)
 
+    # Direct-Ipopt solvers are the default for Armington cases (<=1 good per location).
+    # The general multi-good-per-location case, or an explicit param.jump, routes to JuMP.
+    armington = all(sum(graph.Zjn .> 0, dims = 2) .<= 1)
+    use_jump = get(param, :jump, false) || !armington
+
     if haskey(param, :model)
         model = param.model(optimizer, auxdata)
         if !haskey(param, :recover_allocation)
@@ -228,7 +233,10 @@ function get_model(auxdata)
         end
         recover_allocation = param.recover_allocation 
     elseif param.mobility == 1 && param.cong
-        if all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        if !use_jump # Direct Ipopt (Armington)
+            model = nothing
+            recover_allocation = solve_allocation_mobility_cgc
+        elseif armington
             model = model_mobility_cgc_armington(optimizer, auxdata)
             recover_allocation = recover_allocation_mobility_cgc_armington
         else
@@ -236,7 +244,10 @@ function get_model(auxdata)
             recover_allocation = recover_allocation_mobility_cgc
         end
     elseif param.mobility == 0.5 && param.cong
-        if all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        if !use_jump # Direct Ipopt (Armington)
+            model = nothing
+            recover_allocation = solve_allocation_partial_mobility_cgc
+        elseif armington
             model = model_partial_mobility_cgc_armington(optimizer, auxdata)
             recover_allocation = recover_allocation_partial_mobility_cgc_armington
         else
@@ -247,7 +258,10 @@ function get_model(auxdata)
         if param.beta <= 1 && param.duality > 0 # && param.a < 1
             model = nothing # model_fixed_duality_cgc(optimizer, auxdata)
             recover_allocation = solve_allocation_by_duality_cgc #recover_allocation_fixed_duality_cgc
-        elseif all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        elseif !use_jump # Direct Ipopt primal (Armington), e.g. beta > 1 or duality off
+            model = nothing
+            recover_allocation = solve_allocation_cgc
+        elseif armington
             model = model_fixed_cgc_armington(optimizer, auxdata)
             recover_allocation = recover_allocation_fixed_cgc_armington
         else
@@ -255,7 +269,10 @@ function get_model(auxdata)
             recover_allocation = recover_allocation_fixed_cgc
         end
     elseif param.mobility == 1 && !param.cong
-        if all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        if !use_jump # Direct Ipopt (Armington)
+            model = nothing
+            recover_allocation = solve_allocation_mobility
+        elseif armington
             model = model_mobility_armington(optimizer, auxdata)
             recover_allocation = recover_allocation_mobility_armington
         else
@@ -263,18 +280,24 @@ function get_model(auxdata)
             recover_allocation = recover_allocation_mobility
         end
     elseif param.mobility == 0.5 && !param.cong
-        if all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        if !use_jump # Direct Ipopt (Armington)
+            model = nothing
+            recover_allocation = solve_allocation_partial_mobility
+        elseif armington
             model = model_partial_mobility_armington(optimizer, auxdata)
-            recover_allocation = recover_allocation_partial_mobility_armington    
+            recover_allocation = recover_allocation_partial_mobility_armington
         else
             model = model_partial_mobility(optimizer, auxdata)
-            recover_allocation = recover_allocation_partial_mobility    
+            recover_allocation = recover_allocation_partial_mobility
         end
     elseif param.mobility == 0 && !param.cong
-        if param.beta <= 1 && param.duality > 0 # && param.a < 1 
+        if param.beta <= 1 && param.duality > 0 # && param.a < 1
             model = nothing # model_fixed_duality(optimizer, auxdata)
             recover_allocation = solve_allocation_by_duality # recover_allocation_fixed_duality
-        elseif all(sum(graph.Zjn .> 0, dims = 2) .<= 1) # Armington case
+        elseif !use_jump # Direct Ipopt primal (Armington), e.g. beta > 1 or duality off
+            model = nothing
+            recover_allocation = solve_allocation_primal
+        elseif armington
             model = model_fixed_armington(optimizer, auxdata)
             recover_allocation = recover_allocation_fixed_armington
         else

--- a/src/main/init_parameters.jl
+++ b/src/main/init_parameters.jl
@@ -20,7 +20,8 @@ Returns a `param` dict with the model parameters. These are independent of the g
 - `m::Vector{Float64}=ones(N)`: Vector of weights Nx1 in the cross congestion cost function
 - `annealing::Bool=true`: Switch for the use of annealing at the end of iterations (only if gamma > beta)
 - `verbose::Bool=true`: Switch to turn on/off text output (from Ipopt or other optimizers)
-- `duality::Bool=true`: Switch to turn on/off duality whenever available (fixed labor and beta <= 1). 
+- `duality::Bool=true`: Switch to turn on/off duality whenever available (fixed labor and beta <= 1).
+- `jump::Bool=false`: Force the JuMP solver path instead of the direct-Ipopt solvers. The direct solvers are the default for Armington cases (<=1 good per location); the general multi-good-per-location case always uses JuMP regardless of this switch.
 - `warm_start::Bool=true`: Use the previous solution as a warm start for the next iteration
 - `kappa_min::Float64=1e-5`: Minimum value for road capacities K
 - `min_iter::Int64=20`: Minimum number of iterations
@@ -41,8 +42,8 @@ param = init_parameters(K = 10, labor_mobility = true)
 """
 function init_parameters(; alpha = 0.5, beta = 1, gamma = 1, K = 1, sigma = 5, rho = 2, a = 0.8, N = 1, 
                          labor_mobility = false, cross_good_congestion=false, nu = 2, m = ones(N), 
-                         annealing=true, 
-                         verbose = true, duality = true, warm_start = true, 
+                         annealing=true,
+                         verbose = true, duality = true, warm_start = true, jump = false,
                          kappa_min = 1e-5, min_iter = 20, max_iter = 200, tol = 1e-5, kwargs...)
     param = Dict()
 
@@ -76,12 +77,14 @@ function init_parameters(; alpha = 0.5, beta = 1, gamma = 1, K = 1, sigma = 5, r
     end
     if param[:mobility] == true
         param[:rho] = 0;
+        rho = 0; # full mobility uses rho = 0; keep the utility closures below consistent
     end
     param[:cong] = cross_good_congestion
     param[:annealing] = annealing
     param[:verbose] = verbose
     param[:duality] = duality
     param[:warm_start] = warm_start
+    param[:jump] = jump
 
     # Additional parameters for the numerical part
     param[:tol] = tol

--- a/src/main/optimal_network.jl
+++ b/src/main/optimal_network.jl
@@ -66,7 +66,11 @@ function optimal_network(param, graph; I0=nothing, Il=nothing, Iu=nothing, verbo
     # --------------
     # INITIALIZATION
 
+    # Per-run cache for the direct solvers' Jacobian/Hessian sparsity structures, which depend
+    # only on the graph (not kappa) and so can be computed once and reused across iterations.
+    struct_cache = Dict{Symbol, Any}()
     auxdata = create_auxdata(param, graph, edges, I0)
+    auxdata = (auxdata..., struct_cache = struct_cache)
     model, recover_allocation = get_model(auxdata)
 
     if return_model == 1
@@ -190,6 +194,7 @@ function optimal_network(param, graph; I0=nothing, Il=nothing, Iu=nothing, verbo
             I0 += (1 - weight_old) * I1
             # This creates kappa and updates the model
             auxdata = create_auxdata(param, graph, edges, I0)
+            auxdata = (auxdata..., struct_cache = struct_cache)
             if model !== nothing
                 set_parameter_value.(model[:kappa_ex], auxdata.kappa_ex)
             end

--- a/src/models/solve_allocation_by_duality_cgc.jl
+++ b/src/models/solve_allocation_by_duality_cgc.jl
@@ -268,7 +268,7 @@ function recover_allocation_duality_cgc(x, auxdata)
 
     # Extract price vectors
     Pjn = reshape(x, (graph.J, param.N))
-    PCj = sum(Pjn .^ (1 - param.sigma), dims=2) .^ (1 / (1 - param.sigma))
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2) .^ (1 / (1 - param.sigma)), dims=2)
 
     # Calculate labor allocation
     if param.a < 1
@@ -314,7 +314,7 @@ function recover_allocation_duality_cgc(x, auxdata)
     # Now calculating consumption bundle pre-transport cost
     temp .= Qjk .^ (1+beta) ./ kappa
     temp[nadj] .= 0
-    Dj = Cj + sum(temp, dims = 2)
+    Dj = dropdims(sum(temp, dims = 2), dims=2)
     Djn = Dj .* (Pjn ./ PCj) .^ (-param.sigma) 
     
     return (Pjn=Pjn, PCj=PCj, Ljn=Ljn, Yjn=Yjn, cj=cj, Cj=Cj, Dj=Dj, Djn=Djn, Qjk=Qjk, Qjkn=Qjkn)

--- a/src/models/solve_allocation_cgc.jl
+++ b/src/models/solve_allocation_cgc.jl
@@ -1,0 +1,333 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_cgc.m: fixed labor, cross-good
+# congestion, Armington (<=1 good per location). Used when the dual is
+# unavailable (beta > 1 or duality off). Split directional flows are required
+# because the congestion cost aggregates goods per direction.
+#
+# Variable layout (x):
+#   x = [cj(J); Djn(J*N); Qin_direct(ndeg*N); Qin_indirect(ndeg*N)]
+# Constraint layout (g):
+#   g = [cons_C(J); cons_Q(J*N)]   (final-good availability; balanced flows)
+
+"""
+    solve_allocation_cgc(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the fixed-labor, cross-good-congestion allocation (Armington) via direct
+Ipopt (primal). Used when the dual approach is not available.
+"""
+function solve_allocation_cgc(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_cgc only supports one good at most per location.")
+    end
+
+    n = J + J * N + 2 * ndeg * N
+    if x0 === nothing || isempty(x0)
+        x0 = vcat(fill(1e-6 / graph.Lj[1], J), fill(1e-6, J * N), fill(1e-8, 2 * ndeg * N))
+    end
+
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_cgc(auxdata), () -> hessian_structure_cgc(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    obj = (x) -> objective_cgc(x, saux)
+    grad = (x, grad_f) -> gradient_cgc(x, grad_f, saux)
+    cons = (x, g) -> constraints_cgc(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_cgc(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_cgc(x, rows, cols, obj_factor, lambda, values, saux)
+
+    m = J + J * N
+    x_L = vcat(fill(1e-8, J), fill(1e-6, J * N), fill(1e-8, 2 * ndeg * N))
+    x_U = vcat(fill(Inf, J), fill(Inf, J * N), fill(Inf, 2 * ndeg * N))
+    g_L = fill(-Inf, J + J * N)
+    g_U = fill(0.0, J + J * N)
+
+    x, status, mult_g = run_ipopt_primal(cache, :cgc, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+    results = recover_allocation_cgc(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- index helpers -----
+@inline n_cgc(J, N, ndeg) = J + J * N + 2 * ndeg * N
+@inline col_cj_cgc(j) = j
+@inline col_D_cgc(j, n, J) = J + (n - 1) * J + j
+@inline col_Qd_cgc(i, n, J, N, ndeg) = J + J * N + (n - 1) * ndeg + i
+@inline col_Qi_cgc(i, n, J, N, ndeg) = J + J * N + ndeg * N + (n - 1) * ndeg + i
+@inline row_C_cgc(j) = j
+@inline row_Q_cgc(j, n, J) = J + (n - 1) * J + j
+
+# aggregate availability Dj per location
+function _Dj_cgc(Djn, psigma)
+    return dropdims(sum(Djn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+end
+
+# ----- objective (nonlinear in cj): f = -sum omegaj*Lj*u(cj,hj) -----
+function objective_cgc(x, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    cj = view(x, 1:graph.J)
+    return -sum(graph.omegaj .* graph.Lj .* param.u.(cj, graph.hj))
+end
+
+function gradient_cgc(x::Vector{Float64}, grad_f::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    cj = view(x, 1:graph.J)
+    fill!(grad_f, 0.0)
+    @inbounds for j in 1:graph.J
+        grad_f[j] = -graph.omegaj[j] * graph.Lj[j] * param.uprime(cj[j], graph.hj[j])
+    end
+    return
+end
+
+# ----- constraints -----
+function constraints_cgc(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a = param.m, param.nu, param.beta, param.a
+    psigma = (param.sigma - 1) / param.sigma
+    costfac = (beta + 1) / nu
+
+    cj = view(x, 1:J)
+    Djn = reshape(view(x, J + 1:J + J * N), J, N)
+    Qd = reshape(view(x, J + J * N + 1:J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, J + J * N + ndeg * N + 1:J + J * N + 2 * ndeg * N), ndeg, N)
+    Dj = _Dj_cgc(Djn, psigma)
+
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2))   # ndeg
+    Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cost_d = Apos * (Sd .^ costfac ./ kappa_ex)
+    cost_i = Aneg * (Si .^ costfac ./ kappa_ex)
+    @inbounds for j in 1:J
+        g[row_C_cgc(j)] = cj[j] * graph.Lj[j] + cost_d[j] + cost_i[j] - Dj[j]
+    end
+    @inbounds for nn in 1:N
+        netflow = A * Qd[:, nn] - A * Qi[:, nn]
+        for j in 1:J
+            g[row_Q_cgc(j, nn, J)] = Djn[j, nn] + netflow[j] - graph.Zjn[j, nn] * graph.Lj[j]^a
+        end
+    end
+    return
+end
+
+# ----- Jacobian structure -----
+function jacobian_structure_cgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    # cons_C row j
+    for j in 1:J
+        push_rc!(j, col_cj_cgc(j))
+        for nn in 1:N; push_rc!(j, col_D_cgc(j, nn, J)); end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0; push_rc!(j, col_Qd_cgc(i, nn, J, N, ndeg)); end
+            if A[j, i] < 0; push_rc!(j, col_Qi_cgc(i, nn, J, N, ndeg)); end
+        end
+    end
+    # cons_Q row (j,n)
+    for nn in 1:N, j in 1:J
+        r = row_Q_cgc(j, nn, J)
+        push_rc!(r, col_D_cgc(j, nn, J))
+        for i in 1:ndeg
+            if A[j, i] != 0
+                push_rc!(r, col_Qd_cgc(i, nn, J, N, ndeg))
+                push_rc!(r, col_Qi_cgc(i, nn, J, N, ndeg))
+            end
+        end
+    end
+    return struct_from_triplets(rows, cols, J + J * N, n_cgc(J, N, ndeg))
+end
+
+# ----- Jacobian values -----
+function jacobian_cgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                      values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, sigma = param.m, param.nu, param.beta, param.sigma
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+
+    Djn = reshape(view(x, J + 1:J + J * N), J, N)
+    Qd = reshape(view(x, J + J * N + 1:J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, J + J * N + ndeg * N + 1:J + J * N + 2 * ndeg * N), ndeg, N)
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2))
+    Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cpos = Sd .^ (costfac - 1) ./ kappa_ex   # ndeg
+    cneg = Si .^ (costfac - 1) ./ kappa_ex
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+    # cons_C
+    @inbounds for j in 1:J
+        addv!(j, col_cj_cgc(j), graph.Lj[j])
+        for nn in 1:N
+            addv!(j, col_D_cgc(j, nn, J), -Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma))
+        end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0
+                addv!(j, col_Qd_cgc(i, nn, J, N, ndeg), Apos[j, i] * (1 + beta) * cpos[i] * m[nn] * Qd[i, nn]^(nu - 1))
+            end
+            if A[j, i] < 0
+                addv!(j, col_Qi_cgc(i, nn, J, N, ndeg), Aneg[j, i] * (1 + beta) * cneg[i] * m[nn] * Qi[i, nn]^(nu - 1))
+            end
+        end
+    end
+    # cons_Q
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_cgc(j, nn, J)
+        addv!(r, col_D_cgc(j, nn, J), 1.0)
+        for i in 1:ndeg
+            if A[j, i] != 0
+                addv!(r, col_Qd_cgc(i, nn, J, N, ndeg), A[j, i])
+                addv!(r, col_Qi_cgc(i, nn, J, N, ndeg), -A[j, i])
+            end
+        end
+    end
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J + J * N, n_cgc(J, N, ndeg))
+    return
+end
+
+# ----- Hessian structure -----
+function hessian_structure_cgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    for j in 1:J; push_rc!(col_cj_cgc(j), col_cj_cgc(j)); end
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_D_cgc(j, nn, J); c = col_D_cgc(j, nd, J); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qd_cgc(i, nn, J, N, ndeg); c = col_Qd_cgc(i, nd, J, N, ndeg); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qi_cgc(i, nn, J, N, ndeg); c = col_Qi_cgc(i, nd, J, N, ndeg); r >= c && push_rc!(r, c)
+    end
+    nt = n_cgc(J, N, ndeg)
+    return struct_from_triplets(rows, cols, nt, nt)
+end
+
+# ----- Hessian values -----
+function hessian_cgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                     obj_factor::Float64, lambda::Vector{Float64},
+                     values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, sigma = param.m, param.nu, param.beta, param.sigma
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+
+    cj = view(x, 1:J)
+    Djn = reshape(view(x, J + 1:J + J * N), J, N)
+    Qd = reshape(view(x, J + J * N + 1:J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, J + J * N + ndeg * N + 1:J + J * N + 2 * ndeg * N), ndeg, N)
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2))
+    Si = vec(sum((Qi .^ nu) .* m', dims=2))
+
+    lamC = lambda[1:J]               # final-good (cons_C) multipliers
+    lamApos = Apos' * lamC           # ndeg (origin-node multiplier, direct)
+    lamAneg = Aneg' * lamC           # ndeg (origin-node multiplier, indirect)
+
+    nt = n_cgc(J, N, ndeg)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    # cj diagonal (objective)
+    @inbounds for j in 1:J
+        addv!(col_cj_cgc(j), col_cj_cgc(j), -obj_factor * graph.omegaj[j] * graph.Lj[j] * param.usecond(cj[j], graph.hj[j]))
+    end
+    # Djn block per location (constraint cons_C, weighted by lamC)
+    @inbounds for j in 1:J
+        for nn in 1:N, nd in 1:N
+            r = col_D_cgc(j, nn, J); c = col_D_cgc(j, nd, J)
+            r >= c || continue
+            val = -lamC[j] / sigma * Dj[j]^(-(sigma - 2) / sigma) * Djn[j, nn]^(-1 / sigma) * Djn[j, nd]^(-1 / sigma)
+            if nn == nd
+                val += lamC[j] / sigma * Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma - 1)
+            end
+            addv!(r, c, val)
+        end
+    end
+    # Qin_direct block per edge (constraint cons_C, weighted by lamApos)
+    @inbounds for i in 1:ndeg
+        for nn in 1:N, nd in 1:N
+            r = col_Qd_cgc(i, nn, J, N, ndeg); c = col_Qd_cgc(i, nd, J, N, ndeg)
+            r >= c || continue
+            val = (1 + beta) * (costfac - 1) * nu * lamApos[i] * Sd[i]^(costfac - 2) / kappa_ex[i] *
+                  m[nn] * Qd[i, nn]^(nu - 1) * m[nd] * Qd[i, nd]^(nu - 1)
+            if nn == nd && nu > 1
+                val += (1 + beta) * (nu - 1) * lamApos[i] * Sd[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qd[i, nn]^(nu - 2)
+            end
+            addv!(r, c, val)
+        end
+    end
+    # Qin_indirect block per edge (constraint cons_C, weighted by lamAneg)
+    @inbounds for i in 1:ndeg
+        for nn in 1:N, nd in 1:N
+            r = col_Qi_cgc(i, nn, J, N, ndeg); c = col_Qi_cgc(i, nd, J, N, ndeg)
+            r >= c || continue
+            val = (1 + beta) * (costfac - 1) * nu * lamAneg[i] * Si[i]^(costfac - 2) / kappa_ex[i] *
+                  m[nn] * Qi[i, nn]^(nu - 1) * m[nd] * Qi[i, nd]^(nu - 1)
+            if nn == nd && nu > 1
+                val += (1 + beta) * (nu - 1) * lamAneg[i] * Si[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qi[i, nn]^(nu - 2)
+            end
+            addv!(r, c, val)
+        end
+    end
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nt, nt)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_cgc(x, mult_g, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    psigma = (param.sigma - 1) / param.sigma
+
+    cj = x[1:J]
+    Djn = max.(0.0, reshape(x[J + 1:J + J * N], J, N))
+    Qd = reshape(x[J + J * N + 1:J + J * N + ndeg * N], ndeg, N)
+    Qi = reshape(x[J + J * N + ndeg * N + 1:J + J * N + 2 * ndeg * N], ndeg, N)
+    Dj = _Dj_cgc(Djn, psigma)
+    Lj = graph.Lj
+    Cj = cj .* Lj
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    uj = param.u.(cj, graph.hj)
+    Qin = Qd - Qi
+    Qjkn = gen_network_flows(Qin, graph, N)
+    Pjn = reshape(mult_g[J + 1:J + J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    return (
+        welfare = sum(graph.omegaj .* Lj .* param.u.(cj, graph.hj)),
+        Yjn = Yjn, Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Djn, Cj = Cj, Djn = Djn, Dj = Dj, Ljn = Ljn, Lj = Lj,
+        cj = cj, hj = graph.hj, uj = uj,
+        Pjn = Pjn, PCj = PCj, Qin = Qin, Qjkn = Qjkn,
+    )
+end

--- a/src/models/solve_allocation_mobility.jl
+++ b/src/models/solve_allocation_mobility.jl
@@ -1,0 +1,396 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_mobility.m: the primal problem
+# with full labor mobility, no cross-good congestion, Armington (<=1 good per
+# location). Calls Ipopt.jl's C interface directly with hand-coded sparse
+# gradient/Jacobian/Hessian, mirroring the existing dual solvers.
+#
+# Variable layout (x):
+#   x = [u; Cjn(J*N); Qin_direct(ndeg*N); Qin_indirect(ndeg*N); Lj(J)]
+# Constraint layout (g):
+#   g = [cons_u(J); cons_Q(J*N); cons_L(1)]
+
+"""
+    solve_allocation_mobility(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the full-mobility, no-congestion allocation (Armington) given a matrix of
+kappa (= I^gamma / delta_tau) using a direct Ipopt primal approach.
+
+- `x0`: initial seed for the solver (empty `[]` for the default)
+- `auxdata`: model parameters (param, graph, kappa, kappa_ex, edges)
+- `verbose`: tell Ipopt to display output or not
+
+Returns the results Dict, the Ipopt status code, and the solution vector `x`
+(useful for warm starts).
+"""
+function solve_allocation_mobility(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+
+    # This hand-coded primal supports at most one good per location (Armington)
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_mobility only supports one good at most per location.")
+    end
+
+    # Variable count and default seed
+    n = 1 + J * N + 2 * ndeg * N + J
+    if x0 === nothing || isempty(x0)
+        x0 = vcat(0.0, fill(1e-6, J * N), fill(1e-4, 2 * ndeg * N), fill(1.0 / J, J))
+    end
+
+    # Precompute sparsity structures (superset patterns, x-independent)
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_mobility(auxdata), () -> hessian_structure_mobility(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    # Callbacks (capture the stable auxdata `saux` whose kappa_ex the cache updates in place)
+    obj = (x) -> objective_mobility(x, saux)
+    grad = (x, grad_f) -> gradient_mobility(x, grad_f, saux)
+    cons = (x, g) -> constraints_mobility(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_mobility(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_mobility(x, rows, cols, obj_factor, lambda, values, saux)
+
+    # Bounds
+    m = J + J * N + 1
+    x_L = vcat(-Inf, fill(1e-6, J * N), fill(1e-6, 2 * ndeg * N), fill(1e-8, J))
+    x_U = vcat(Inf, fill(Inf, J * N), fill(Inf, 2 * ndeg * N), fill(1.0, J))
+    # cons_u <= 0, cons_Q <= 0 (balanced flow), cons_L == 0 (labor). NB: the MATLAB
+    # reference uses a loose 1e-3 upper bound on cons_Q, which inflates welfare here
+    # (prices are O(1), not rescaled as in MATLAB), so we keep the exact <= 0 bound.
+    g_L = vcat(fill(-Inf, J), fill(-Inf, J * N), 0.0)
+    g_U = vcat(fill(0.0, J), fill(0.0, J * N), 0.0)
+
+    x, status, mult_g = run_ipopt_primal(cache, :mobility, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+
+    results = recover_allocation_mobility(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- column / row index helpers -----
+# u:                col 1
+# Cjn[j,n]:         col 1 + (n-1)*J + j
+# Qin_direct[i,n]:  col 1 + J*N + (n-1)*ndeg + i
+# Qin_indirect[i,n]:col 1 + J*N + ndeg*N + (n-1)*ndeg + i
+# Lj[j]:            col 1 + J*N + 2*ndeg*N + j
+# cons_u[j]:        row j
+# cons_Q[j,n]:      row J + (n-1)*J + j
+# cons_L:           row J + J*N + 1
+@inline col_C_mob(j, n, J) = 1 + (n - 1) * J + j
+@inline col_Qd_mob(i, n, J, N, ndeg) = 1 + J * N + (n - 1) * ndeg + i
+@inline col_Qi_mob(i, n, J, N, ndeg) = 1 + J * N + ndeg * N + (n - 1) * ndeg + i
+@inline col_L_mob(j, J, N, ndeg) = 1 + J * N + 2 * ndeg * N + j
+@inline row_Q_mob(j, n, J) = J + (n - 1) * J + j
+
+# ----- objective and gradient (objective is linear: f = -u) -----
+function objective_mobility(x, auxdata)
+    return -x[1]
+end
+
+function gradient_mobility(x::Vector{Float64}, grad_f::Vector{Float64}, auxdata)
+    fill!(grad_f, 0.0)
+    grad_f[1] = -1.0
+    return
+end
+
+# ----- constraints -----
+function constraints_mobility(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    Apos = auxdata.edges.Apos
+    Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    psigma = (param.sigma - 1) / param.sigma
+    beta = param.beta
+
+    u = x[1]
+    Cjn = reshape(view(x, 2:1 + J * N), J, N)
+    Qd = reshape(view(x, 2 + J * N:1 + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J * N + ndeg * N:1 + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J * N + 2 * ndeg * N:n_mobility(J, N, ndeg))
+
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    # cons_u (J): Lj*u - U(Cj, Hj)
+    @inbounds for j in 1:J
+        g[j] = Lj[j] * u - (Cj[j] / param.alpha)^param.alpha * (graph.Hj[j] / (1 - param.alpha))^(1 - param.alpha)
+    end
+
+    # cons_Q (J*N): Cjn + Apos*(Qd^(1+beta)/kappa) + Aneg*(Qi^(1+beta)/kappa) + A*Qd - A*Qi - Yjn
+    @inbounds for nn in 1:N
+        cd = Qd[:, nn] .^ (1 + beta) ./ kappa_ex
+        ci = Qi[:, nn] .^ (1 + beta) ./ kappa_ex
+        flow = Apos * cd + Aneg * ci + A * Qd[:, nn] - A * Qi[:, nn]
+        for j in 1:J
+            g[row_Q_mob(j, nn, J)] = Cjn[j, nn] + flow[j] - graph.Zjn[j, nn] * Lj[j]^param.a
+        end
+    end
+
+    # cons_L (1): sum(Lj) - 1
+    g[J + J * N + 1] = sum(Lj) - 1.0
+    return
+end
+
+@inline n_mobility(J, N, ndeg) = 1 + J * N + 2 * ndeg * N + J
+
+# ----- Jacobian structure (superset, matches MATLAB jacobianstructure) -----
+function jacobian_structure_mobility(auxdata)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    rows = Int[]
+    cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+
+    # cons_u row j
+    for j in 1:J
+        push_rc!(j, 1)                              # u
+        for nn in 1:N
+            push_rc!(j, col_C_mob(j, nn, J))        # Cjn[j,n]
+        end
+        push_rc!(j, col_L_mob(j, J, N, ndeg))       # Lj[j]
+    end
+    # cons_Q row (j,n)
+    for nn in 1:N, j in 1:J
+        r = row_Q_mob(j, nn, J)
+        push_rc!(r, col_C_mob(j, nn, J))            # Cjn eye
+        for i in 1:ndeg
+            if A[j, i] != 0
+                push_rc!(r, col_Qd_mob(i, nn, J, N, ndeg))
+                push_rc!(r, col_Qi_mob(i, nn, J, N, ndeg))
+            end
+        end
+        push_rc!(r, col_L_mob(j, J, N, ndeg))       # Lj (repmat eye)
+    end
+    # cons_L row
+    rL = J + J * N + 1
+    for j in 1:J
+        push_rc!(rL, col_L_mob(j, J, N, ndeg))
+    end
+
+    return struct_from_triplets(rows, cols, J + J * N + 1, n_mobility(J, N, ndeg))
+end
+
+# ----- Jacobian values -----
+function jacobian_mobility(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                           values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct
+        rows .= r
+        cols .= c
+        return
+    end
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    Apos = auxdata.edges.Apos
+    Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    sigma, alpha, beta, a = param.sigma, param.alpha, param.beta, param.a
+    psigma = (sigma - 1) / sigma
+
+    u = x[1]
+    Cjn = reshape(view(x, 2:1 + J * N), J, N)
+    Qd = reshape(view(x, 2 + J * N:1 + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J * N + ndeg * N:1 + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J * N + 2 * ndeg * N:n_mobility(J, N, ndeg))
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+
+    # cons_u
+    @inbounds for j in 1:J
+        addv!(j, 1, Lj[j])                                       # d/du
+        cu = felicity_c(Cj[j], graph.Hj[j], alpha)
+        for nn in 1:N
+            addv!(j, col_C_mob(j, nn, J), -Cjn[j, nn]^(-1 / sigma) * Cj[j]^(1 / sigma) * cu)
+        end
+        addv!(j, col_L_mob(j, J, N, ndeg), u)                   # d/dLj
+    end
+    # cons_Q
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_mob(j, nn, J)
+        addv!(r, col_C_mob(j, nn, J), 1.0)                      # d/dCjn
+        for i in 1:ndeg
+            if A[j, i] != 0
+                addv!(r, col_Qd_mob(i, nn, J, N, ndeg), A[j, i] + (1 + beta) * Apos[j, i] * Qd[i, nn]^beta / kappa_ex[i])
+                addv!(r, col_Qi_mob(i, nn, J, N, ndeg), -A[j, i] + (1 + beta) * Aneg[j, i] * Qi[i, nn]^beta / kappa_ex[i])
+            end
+        end
+        addv!(r, col_L_mob(j, J, N, ndeg), -a * graph.Zjn[j, nn] * Lj[j]^(a - 1))  # d/dLj
+    end
+    # cons_L
+    rL = J + J * N + 1
+    @inbounds for j in 1:J
+        addv!(rL, col_L_mob(j, J, N, ndeg), 1.0)
+    end
+
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J + J * N + 1, n_mobility(J, N, ndeg))
+    return
+end
+
+# ----- Hessian structure (superset, lower triangle, matches MATLAB) -----
+function hessian_structure_mobility(auxdata)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+
+    # (Cjn, Cjn) full N*N block per location j (lower triangle)
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_C_mob(j, nn, J)
+        c = col_C_mob(j, nd, J)
+        if r >= c
+            push_rc!(r, c)
+        end
+    end
+    # (Qdir, Qdir) diagonal
+    for nn in 1:N, i in 1:ndeg
+        cc = col_Qd_mob(i, nn, J, N, ndeg); push_rc!(cc, cc)
+    end
+    # (Qindir, Qindir) diagonal
+    for nn in 1:N, i in 1:ndeg
+        cc = col_Qi_mob(i, nn, J, N, ndeg); push_rc!(cc, cc)
+    end
+    # (Lj, u) and (Lj, Lj) diagonal
+    for j in 1:J
+        cL = col_L_mob(j, J, N, ndeg)
+        push_rc!(cL, 1)        # (Lj, u)
+        push_rc!(cL, cL)       # (Lj, Lj)
+    end
+
+    nn_tot = n_mobility(J, N, ndeg)
+    return struct_from_triplets(rows, cols, nn_tot, nn_tot)
+end
+
+# ----- Hessian values (Lagrangian; objective linear so obj_factor unused) -----
+function hessian_mobility(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                          obj_factor::Float64, lambda::Vector{Float64},
+                          values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct
+        rows .= r
+        cols .= c
+        return
+    end
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    Apos = auxdata.edges.Apos
+    Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    sigma, beta, a, alpha = param.sigma, param.beta, param.a, param.alpha
+    psigma = (sigma - 1) / sigma
+
+    Cjn = reshape(view(x, 2:1 + J * N), J, N)
+    Qd = reshape(view(x, 2 + J * N:1 + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J * N + ndeg * N:1 + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J * N + 2 * ndeg * N:n_mobility(J, N, ndeg))
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    omegaj = lambda[1:J]
+    Pjn = reshape(lambda[J + 1:J + J * N], J, N)
+
+    nn_tot = n_mobility(J, N, ndeg)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    # (Cjn, Cjn) block per location j: diag(Hcdiag) + Hcnondiag
+    @inbounds for j in 1:J
+        up = felicity_c(Cj[j], graph.Hj[j], alpha)
+        us = felicity_cc(Cj[j], graph.Hj[j], alpha)
+        pref = -(omegaj[j] * us * Cj[j]^(2 / sigma) + (1 / sigma) * omegaj[j] * up * Cj[j]^(2 / sigma - 1))
+        for nn in 1:N, nd in 1:N
+            r = col_C_mob(j, nn, J)
+            c = col_C_mob(j, nd, J)
+            r >= c || continue
+            val = pref * Cjn[j, nn]^(-1 / sigma) * Cjn[j, nd]^(-1 / sigma)   # Hcnondiag
+            if nn == nd
+                val += (1 / sigma) * omegaj[j] * up * Cj[j]^(1 / sigma) * Cjn[j, nn]^(-1 / sigma - 1)  # Hcdiag
+            end
+            addv!(r, c, val)
+        end
+    end
+    # (Qdir, Qdir) and (Qindir, Qindir) diagonals
+    @inbounds for nn in 1:N
+        ApP = Apos' * Pjn[:, nn]
+        AnP = Aneg' * Pjn[:, nn]
+        for i in 1:ndeg
+            cd = col_Qd_mob(i, nn, J, N, ndeg)
+            addv!(cd, cd, (1 + beta) * beta * Qd[i, nn]^(beta - 1) / kappa_ex[i] * ApP[i])
+            ci = col_Qi_mob(i, nn, J, N, ndeg)
+            addv!(ci, ci, (1 + beta) * beta * Qi[i, nn]^(beta - 1) / kappa_ex[i] * AnP[i])
+        end
+    end
+    # (Lj, u) = omegaj  and (Lj, Lj) = Hl
+    @inbounds for j in 1:J
+        cL = col_L_mob(j, J, N, ndeg)
+        addv!(cL, 1, omegaj[j])
+        hl = 0.0
+        for nn in 1:N
+            # NB: Zjn factor is required (production Yjn = Zjn*Lj^a). The MATLAB
+            # reference omits it in Hl, which is a latent bug for Zjn != 1.
+            hl += -a * (a - 1) * graph.Zjn[j, nn] * Pjn[j, nn] * Lj[j]^(a - 2)
+        end
+        addv!(cL, cL, hl)
+    end
+
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nn_tot, nn_tot)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_mobility(x, mult_g, auxdata)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    psigma = (param.sigma - 1) / param.sigma
+
+    u = x[1]
+    Cjn = reshape(x[2:1 + J * N], J, N)
+    Qd = reshape(x[2 + J * N:1 + J * N + ndeg * N], ndeg, N)
+    Qi = reshape(x[2 + J * N + ndeg * N:1 + J * N + 2 * ndeg * N], ndeg, N)
+    Lj = x[2 + J * N + 2 * ndeg * N:n_mobility(J, N, ndeg)]
+
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    cj = ifelse.(Lj .== 0, 0.0, Cj ./ Lj)
+    hj = ifelse.(Lj .== 0, 0.0, graph.Hj ./ Lj)
+    uj = param.u.(cj, hj)
+    Qin = Qd - Qi
+    Qjkn = gen_network_flows(Qin, graph, N)
+
+    Pjn = reshape(mult_g[J + 1:J + J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    results = (
+        welfare = u,
+        Yjn = Yjn,
+        Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Cjn,
+        Cj = Cj,
+        Ljn = Ljn,
+        Lj = Lj,
+        cj = cj,
+        hj = hj,
+        uj = uj,
+        Pjn = Pjn,
+        PCj = PCj,
+        Qin = Qin,
+        Qjkn = Qjkn,
+    )
+    return results
+end

--- a/src/models/solve_allocation_mobility_cgc.jl
+++ b/src/models/solve_allocation_mobility_cgc.jl
@@ -1,0 +1,343 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_mobility_cgc.m: full labor
+# mobility, cross-good congestion, Armington (<=1 good per location). Combines
+# the cgc final-good/flow structure with the mobility wrapper (utility level u,
+# aggregate consumption Cj, labor Lj, total-labor constraint).
+#
+# Variable layout (x):
+#   x = [u; Cj(J); Djn(J*N); Qin_direct(ndeg*N); Qin_indirect(ndeg*N); Lj(J)]
+# Constraint layout (g):
+#   g = [cons_u(J); cons_C(J); cons_Q(J*N); cons_L(1)]
+
+"""
+    solve_allocation_mobility_cgc(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the full-mobility, cross-good-congestion allocation (Armington) via direct Ipopt.
+"""
+function solve_allocation_mobility_cgc(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_mobility_cgc only supports one good at most per location.")
+    end
+
+    n = 1 + J + J * N + 2 * ndeg * N + J
+    if x0 === nothing || isempty(x0)
+        x0 = vcat(0.0, fill(1e-6 * J, J), fill(1e-6, J * N), fill(1e-6, 2 * ndeg * N), fill(1.0 / J, J))
+    end
+
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_mcgc(auxdata), () -> hessian_structure_mcgc(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    obj = (x) -> -x[1]
+    grad = (x, grad_f) -> (fill!(grad_f, 0.0); grad_f[1] = -1.0; nothing)
+    cons = (x, g) -> constraints_mcgc(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_mcgc(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_mcgc(x, rows, cols, obj_factor, lambda, values, saux)
+
+    m = J + J + J * N + 1
+    x_L = vcat(-Inf, fill(1e-6, J), fill(1e-6, J * N), fill(1e-6, 2 * ndeg * N), fill(1e-8, J))
+    x_U = vcat(Inf, fill(Inf, J), fill(Inf, J * N), fill(Inf, 2 * ndeg * N), fill(Inf, J))
+    g_L = vcat(fill(-Inf, J + J + J * N), 0.0)
+    g_U = vcat(fill(0.0, J + J + J * N), 0.0)
+
+    x, status, mult_g = run_ipopt_primal(cache, :mobility_cgc, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+    results = recover_allocation_mcgc(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- index helpers -----
+@inline n_mcgc(J, N, ndeg) = 1 + J + J * N + 2 * ndeg * N + J
+@inline col_Cj_mc(j, J) = 1 + j
+@inline col_D_mc(j, n, J) = 1 + J + (n - 1) * J + j
+@inline col_Qd_mc(i, n, J, N, ndeg) = 1 + J + J * N + (n - 1) * ndeg + i
+@inline col_Qi_mc(i, n, J, N, ndeg) = 1 + J + J * N + ndeg * N + (n - 1) * ndeg + i
+@inline col_L_mc(j, J, N, ndeg) = 1 + J + J * N + 2 * ndeg * N + j
+@inline row_u_mc(j) = j
+@inline row_C_mc(j, J) = J + j
+@inline row_Q_mc(j, n, J) = 2 * J + (n - 1) * J + j
+@inline row_L_mc(J, N) = 2 * J + J * N + 1
+
+# ----- constraints -----
+function constraints_mcgc(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, alpha = param.m, param.nu, param.beta, param.a, param.alpha
+    psigma = (param.sigma - 1) / param.sigma
+    costfac = (beta + 1) / nu
+
+    u = x[1]
+    Cj = view(x, 2:1 + J)
+    Djn = reshape(view(x, 2 + J:1 + J + J * N), J, N)
+    Qd = reshape(view(x, 2 + J + J * N:1 + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J + J * N + ndeg * N:1 + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J + J * N + 2 * ndeg * N:n_mcgc(J, N, ndeg))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2))
+    Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cost_d = Apos * (Sd .^ costfac ./ kappa_ex)
+    cost_i = Aneg * (Si .^ costfac ./ kappa_ex)
+
+    @inbounds for j in 1:J
+        g[row_u_mc(j)] = u * Lj[j] - felicity(Cj[j], graph.Hj[j], alpha)
+        g[row_C_mc(j, J)] = Cj[j] + cost_d[j] + cost_i[j] - Dj[j]
+    end
+    @inbounds for nn in 1:N
+        netflow = A * Qd[:, nn] - A * Qi[:, nn]
+        for j in 1:J
+            g[row_Q_mc(j, nn, J)] = Djn[j, nn] + netflow[j] - graph.Zjn[j, nn] * Lj[j]^a
+        end
+    end
+    g[row_L_mc(J, N)] = sum(Lj) - 1.0
+    return
+end
+
+# ----- Jacobian structure -----
+function jacobian_structure_mcgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    # cons_u row j: u, Cj[j], Lj[j]
+    for j in 1:J
+        push_rc!(j, 1)
+        push_rc!(j, col_Cj_mc(j, J))
+        push_rc!(j, col_L_mc(j, J, N, ndeg))
+    end
+    # cons_C row j: Cj[j], Djn[j,n], Qd/Qi at incident edges
+    for j in 1:J
+        r = row_C_mc(j, J)
+        push_rc!(r, col_Cj_mc(j, J))
+        for nn in 1:N; push_rc!(r, col_D_mc(j, nn, J)); end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0; push_rc!(r, col_Qd_mc(i, nn, J, N, ndeg)); end
+            if A[j, i] < 0; push_rc!(r, col_Qi_mc(i, nn, J, N, ndeg)); end
+        end
+    end
+    # cons_Q row (j,n): Djn[j,n], Qd/Qi, Lj[j]
+    for nn in 1:N, j in 1:J
+        r = row_Q_mc(j, nn, J)
+        push_rc!(r, col_D_mc(j, nn, J))
+        for i in 1:ndeg
+            if A[j, i] != 0
+                push_rc!(r, col_Qd_mc(i, nn, J, N, ndeg))
+                push_rc!(r, col_Qi_mc(i, nn, J, N, ndeg))
+            end
+        end
+        push_rc!(r, col_L_mc(j, J, N, ndeg))
+    end
+    # cons_L row: all Lj
+    for j in 1:J; push_rc!(row_L_mc(J, N), col_L_mc(j, J, N, ndeg)); end
+    return struct_from_triplets(rows, cols, J + J + J * N + 1, n_mcgc(J, N, ndeg))
+end
+
+# ----- Jacobian values -----
+function jacobian_mcgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                       values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, sigma, alpha = param.m, param.nu, param.beta, param.a, param.sigma, param.alpha
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+
+    u = x[1]
+    Cj = view(x, 2:1 + J)
+    Djn = reshape(view(x, 2 + J:1 + J + J * N), J, N)
+    Qd = reshape(view(x, 2 + J + J * N:1 + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J + J * N + ndeg * N:1 + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J + J * N + 2 * ndeg * N:n_mcgc(J, N, ndeg))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2)); Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cpos = Sd .^ (costfac - 1) ./ kappa_ex; cneg = Si .^ (costfac - 1) ./ kappa_ex
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+    # cons_u
+    @inbounds for j in 1:J
+        addv!(j, 1, Lj[j])
+        addv!(j, col_Cj_mc(j, J), -felicity_c(Cj[j], graph.Hj[j], alpha))
+        addv!(j, col_L_mc(j, J, N, ndeg), u)
+    end
+    # cons_C
+    @inbounds for j in 1:J
+        r = row_C_mc(j, J)
+        addv!(r, col_Cj_mc(j, J), 1.0)
+        for nn in 1:N
+            addv!(r, col_D_mc(j, nn, J), -Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma))
+        end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0
+                addv!(r, col_Qd_mc(i, nn, J, N, ndeg), Apos[j, i] * (1 + beta) * cpos[i] * m[nn] * Qd[i, nn]^(nu - 1))
+            end
+            if A[j, i] < 0
+                addv!(r, col_Qi_mc(i, nn, J, N, ndeg), Aneg[j, i] * (1 + beta) * cneg[i] * m[nn] * Qi[i, nn]^(nu - 1))
+            end
+        end
+    end
+    # cons_Q
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_mc(j, nn, J)
+        addv!(r, col_D_mc(j, nn, J), 1.0)
+        for i in 1:ndeg
+            if A[j, i] != 0
+                addv!(r, col_Qd_mc(i, nn, J, N, ndeg), A[j, i])
+                addv!(r, col_Qi_mc(i, nn, J, N, ndeg), -A[j, i])
+            end
+        end
+        addv!(r, col_L_mc(j, J, N, ndeg), -a * graph.Zjn[j, nn] * Lj[j]^(a - 1))
+    end
+    # cons_L
+    @inbounds for j in 1:J; addv!(row_L_mc(J, N), col_L_mc(j, J, N, ndeg), 1.0); end
+
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J + J + J * N + 1, n_mcgc(J, N, ndeg))
+    return
+end
+
+# ----- Hessian structure -----
+function hessian_structure_mcgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    for j in 1:J; push_rc!(col_Cj_mc(j, J), col_Cj_mc(j, J)); end             # (Cj,Cj)
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_D_mc(j, nn, J); c = col_D_mc(j, nd, J); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qd_mc(i, nn, J, N, ndeg); c = col_Qd_mc(i, nd, J, N, ndeg); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qi_mc(i, nn, J, N, ndeg); c = col_Qi_mc(i, nd, J, N, ndeg); r >= c && push_rc!(r, c)
+    end
+    for j in 1:J
+        cL = col_L_mc(j, J, N, ndeg)
+        push_rc!(cL, 1)        # (Lj, u)
+        push_rc!(cL, cL)       # (Lj, Lj)
+    end
+    nt = n_mcgc(J, N, ndeg)
+    return struct_from_triplets(rows, cols, nt, nt)
+end
+
+# ----- Hessian values (objective linear; obj_factor unused) -----
+function hessian_mcgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                      obj_factor::Float64, lambda::Vector{Float64},
+                      values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, sigma, alpha = param.m, param.nu, param.beta, param.a, param.sigma, param.alpha
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+
+    Cj = view(x, 2:1 + J)
+    Djn = reshape(view(x, 2 + J:1 + J + J * N), J, N)
+    Qd = reshape(view(x, 2 + J + J * N:1 + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, 2 + J + J * N + ndeg * N:1 + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, 2 + J + J * N + 2 * ndeg * N:n_mcgc(J, N, ndeg))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2)); Si = vec(sum((Qi .^ nu) .* m', dims=2))
+
+    omega = lambda[1:J]              # cons_u multipliers
+    lamC = lambda[J + 1:2 * J]       # cons_C multipliers
+    Pjn = reshape(lambda[2 * J + 1:2 * J + J * N], J, N)  # cons_Q multipliers
+    lamApos = Apos' * lamC; lamAneg = Aneg' * lamC
+
+    nt = n_mcgc(J, N, ndeg)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    # (Cj,Cj) from cons_u (omega-weighted)
+    @inbounds for j in 1:J
+        addv!(col_Cj_mc(j, J), col_Cj_mc(j, J), -omega[j] * felicity_cc(Cj[j], graph.Hj[j], alpha))
+    end
+    # Djn block (cons_C, lamC)
+    @inbounds for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_D_mc(j, nn, J); c = col_D_mc(j, nd, J); r >= c || continue
+        val = -lamC[j] / sigma * Dj[j]^(-(sigma - 2) / sigma) * Djn[j, nn]^(-1 / sigma) * Djn[j, nd]^(-1 / sigma)
+        nn == nd && (val += lamC[j] / sigma * Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma - 1))
+        addv!(r, c, val)
+    end
+    # Qd block (cons_C, lamApos)
+    @inbounds for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qd_mc(i, nn, J, N, ndeg); c = col_Qd_mc(i, nd, J, N, ndeg); r >= c || continue
+        val = (1 + beta) * (costfac - 1) * nu * lamApos[i] * Sd[i]^(costfac - 2) / kappa_ex[i] *
+              m[nn] * Qd[i, nn]^(nu - 1) * m[nd] * Qd[i, nd]^(nu - 1)
+        (nn == nd && nu > 1) && (val += (1 + beta) * (nu - 1) * lamApos[i] * Sd[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qd[i, nn]^(nu - 2))
+        addv!(r, c, val)
+    end
+    # Qi block (cons_C, lamAneg)
+    @inbounds for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qi_mc(i, nn, J, N, ndeg); c = col_Qi_mc(i, nd, J, N, ndeg); r >= c || continue
+        val = (1 + beta) * (costfac - 1) * nu * lamAneg[i] * Si[i]^(costfac - 2) / kappa_ex[i] *
+              m[nn] * Qi[i, nn]^(nu - 1) * m[nd] * Qi[i, nd]^(nu - 1)
+        (nn == nd && nu > 1) && (val += (1 + beta) * (nu - 1) * lamAneg[i] * Si[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qi[i, nn]^(nu - 2))
+        addv!(r, c, val)
+    end
+    # (Lj,u) and (Lj,Lj) from cons_u and cons_Q (production)
+    @inbounds for j in 1:J
+        cL = col_L_mc(j, J, N, ndeg)
+        addv!(cL, 1, omega[j])
+        hll = 0.0
+        for nn in 1:N
+            hll += -a * (a - 1) * Pjn[j, nn] * graph.Zjn[j, nn] * Lj[j]^(a - 2)
+        end
+        addv!(cL, cL, hll)
+    end
+
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nt, nt)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_mcgc(x, mult_g, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    psigma = (param.sigma - 1) / param.sigma
+
+    u = x[1]
+    Cj = x[2:1 + J]
+    Djn = max.(0.0, reshape(x[2 + J:1 + J + J * N], J, N))
+    Qd = reshape(x[2 + J + J * N:1 + J + J * N + ndeg * N], ndeg, N)
+    Qi = reshape(x[2 + J + J * N + ndeg * N:1 + J + J * N + 2 * ndeg * N], ndeg, N)
+    Lj = x[2 + J + J * N + 2 * ndeg * N:n_mcgc(J, N, ndeg)]
+    Dj = _Dj_cgc(Djn, psigma)
+    cj = ifelse.(Lj .== 0, 0.0, Cj ./ Lj)
+    hj = ifelse.(Lj .== 0, 0.0, graph.Hj ./ Lj)
+    uj = param.u.(cj, hj)
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    Qin = Qd - Qi
+    Qjkn = gen_network_flows(Qin, graph, N)
+    Pjn = reshape(mult_g[2 * J + 1:2 * J + J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    return (
+        welfare = u,
+        Yjn = Yjn, Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Djn, Cj = Cj, Djn = Djn, Dj = Dj, Ljn = Ljn, Lj = Lj,
+        cj = cj, hj = hj, uj = uj,
+        Pjn = Pjn, PCj = PCj, Qin = Qin, Qjkn = Qjkn,
+    )
+end

--- a/src/models/solve_allocation_partial_mobility.jl
+++ b/src/models/solve_allocation_partial_mobility.jl
@@ -1,0 +1,327 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_partial_mobility.m: the primal
+# problem with labor mobile within regions, no cross-good congestion, Armington
+# (<=1 good per location). Uses a single signed flow Qin (as the MATLAB and JuMP
+# references do for this case). NB: the split-flow formulation used for full
+# mobility lands on worse local optima here because partial mobility's bilinear
+# Lj*ur term makes the inner problem non-convex.
+#
+# Variable layout (x):
+#   x = [ur(R); Cjn(J*N); Qin(ndeg*N); Lj(J)]   (R = nregions)
+# Constraint layout (g):
+#   g = [cons_u(J); cons_Q(J*N); cons_L(R)]
+
+"""
+    solve_allocation_partial_mobility(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the partial-mobility, no-congestion allocation (Armington) via direct Ipopt.
+"""
+function solve_allocation_partial_mobility(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_partial_mobility only supports one good at most per location.")
+    end
+
+    n = R + J * N + ndeg * N + J
+    if x0 === nothing || isempty(x0)
+        counts = zeros(R)
+        for j in 1:J; counts[graph.region[j]] += 1; end
+        Lj0 = [graph.Lr[graph.region[j]] / counts[graph.region[j]] for j in 1:J]
+        x0 = vcat(zeros(R), fill(1e-6, J * N), zeros(ndeg * N), Lj0)
+    end
+
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_pmob(auxdata), () -> hessian_structure_pmob(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    obj = (x) -> objective_pmob(x, saux)
+    grad = (x, grad_f) -> gradient_pmob(x, grad_f, saux)
+    cons = (x, g) -> constraints_pmob(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_pmob(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_pmob(x, rows, cols, obj_factor, lambda, values, saux)
+
+    m = J + J * N + R
+    x_L = vcat(fill(-Inf, R), fill(1e-6, J * N), fill(-Inf, ndeg * N), fill(1e-8, J))
+    x_U = vcat(fill(Inf, R), fill(Inf, J * N), fill(Inf, ndeg * N), fill(Inf, J))
+    g_L = vcat(fill(-Inf, J), fill(-Inf, J * N), zeros(R))
+    g_U = vcat(fill(0.0, J), fill(0.0, J * N), zeros(R))
+
+    x, status, mult_g = run_ipopt_primal(cache, :partial_mobility, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+    results = recover_allocation_pmob(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- index helpers (R = nregions offset, single flow Qin) -----
+@inline n_pmob(J, N, ndeg, R) = R + J * N + ndeg * N + J
+@inline col_ur_pm(r) = r
+@inline col_C_pm(j, n, J, R) = R + (n - 1) * J + j
+@inline col_Q_pm(i, n, J, N, ndeg, R) = R + J * N + (n - 1) * ndeg + i
+@inline col_L_pm(j, J, N, ndeg, R) = R + J * N + ndeg * N + j
+@inline row_Q_pm(j, n, J) = J + (n - 1) * J + j
+@inline row_L_pm(r, J, N) = J + J * N + r
+
+# ----- objective (linear in ur) -----
+function objective_pmob(x, auxdata)
+    graph = auxdata.graph
+    return -sum(graph.omegar[r] * graph.Lr[r] * x[r] for r in 1:graph.nregions)
+end
+
+function gradient_pmob(x::Vector{Float64}, grad_f::Vector{Float64}, auxdata)
+    graph = auxdata.graph
+    fill!(grad_f, 0.0)
+    @inbounds for r in 1:graph.nregions
+        grad_f[r] = -graph.omegar[r] * graph.Lr[r]
+    end
+    return
+end
+
+# ----- constraints -----
+function constraints_pmob(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    psigma = (param.sigma - 1) / param.sigma
+    beta, alpha, a = param.beta, param.alpha, param.a
+    region = graph.region
+
+    ur = view(x, 1:R)
+    Cjn = reshape(view(x, R + 1:R + J * N), J, N)
+    Qin = reshape(view(x, R + J * N + 1:R + J * N + ndeg * N), ndeg, N)
+    Lj = view(x, R + J * N + ndeg * N + 1:n_pmob(J, N, ndeg, R))
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    @inbounds for j in 1:J
+        g[j] = Lj[j] * ur[region[j]] - felicity(Cj[j], graph.Hj[j], alpha)
+    end
+    @inbounds for nn in 1:N
+        q = Qin[:, nn]
+        cost = abs.(q) .^ (1 + beta) ./ kappa_ex
+        pos = q .> 0
+        cost_at = Apos * (cost .* pos) + Aneg * (cost .* .!pos)   # charged at origin node
+        flow = A * q + cost_at
+        for j in 1:J
+            g[row_Q_pm(j, nn, J)] = Cjn[j, nn] + flow[j] - graph.Zjn[j, nn] * Lj[j]^a
+        end
+    end
+    @inbounds for r in 1:R
+        g[row_L_pm(r, J, N)] = -graph.Lr[r]
+    end
+    @inbounds for j in 1:J
+        g[row_L_pm(region[j], J, N)] += Lj[j]
+    end
+    return
+end
+
+# ----- Jacobian structure -----
+function jacobian_structure_pmob(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; region = graph.region
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+
+    for j in 1:J
+        push_rc!(j, col_ur_pm(region[j]))
+        for nn in 1:N; push_rc!(j, col_C_pm(j, nn, J, R)); end
+        push_rc!(j, col_L_pm(j, J, N, ndeg, R))
+    end
+    for nn in 1:N, j in 1:J
+        r = row_Q_pm(j, nn, J)
+        push_rc!(r, col_C_pm(j, nn, J, R))
+        for i in 1:ndeg
+            if A[j, i] != 0
+                push_rc!(r, col_Q_pm(i, nn, J, N, ndeg, R))
+            end
+        end
+        push_rc!(r, col_L_pm(j, J, N, ndeg, R))
+    end
+    for j in 1:J
+        push_rc!(row_L_pm(region[j], J, N), col_L_pm(j, J, N, ndeg, R))
+    end
+    return struct_from_triplets(rows, cols, J + J * N + R, n_pmob(J, N, ndeg, R))
+end
+
+# ----- Jacobian values -----
+function jacobian_pmob(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                       values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    sigma, alpha, beta, a = param.sigma, param.alpha, param.beta, param.a
+    psigma = (sigma - 1) / sigma
+    region = graph.region
+
+    ur = view(x, 1:R)
+    Cjn = reshape(view(x, R + 1:R + J * N), J, N)
+    Qin = reshape(view(x, R + J * N + 1:R + J * N + ndeg * N), ndeg, N)
+    Lj = view(x, R + J * N + ndeg * N + 1:n_pmob(J, N, ndeg, R))
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+
+    @inbounds for j in 1:J
+        addv!(j, col_ur_pm(region[j]), Lj[j])
+        cu = felicity_c(Cj[j], graph.Hj[j], alpha)
+        for nn in 1:N
+            addv!(j, col_C_pm(j, nn, J, R), -Cjn[j, nn]^(-1 / sigma) * Cj[j]^(1 / sigma) * cu)
+        end
+        addv!(j, col_L_pm(j, J, N, ndeg, R), ur[region[j]])
+    end
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_pm(j, nn, J)
+        addv!(r, col_C_pm(j, nn, J, R), 1.0)
+        for i in 1:ndeg
+            if A[j, i] != 0
+                q = Qin[i, nn]
+                Morig = q > 0 ? Apos[j, i] : Aneg[j, i]
+                dcost = (1 + beta) * Morig * sign(q) * abs(q)^beta / kappa_ex[i]
+                addv!(r, col_Q_pm(i, nn, J, N, ndeg, R), A[j, i] + dcost)
+            end
+        end
+        addv!(r, col_L_pm(j, J, N, ndeg, R), -a * graph.Zjn[j, nn] * Lj[j]^(a - 1))
+    end
+    @inbounds for j in 1:J
+        addv!(row_L_pm(region[j], J, N), col_L_pm(j, J, N, ndeg, R), 1.0)
+    end
+
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J + J * N + R, n_pmob(J, N, ndeg, R))
+    return
+end
+
+# ----- Hessian structure -----
+function hessian_structure_pmob(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    region = graph.region
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_C_pm(j, nn, J, R); c = col_C_pm(j, nd, J, R)
+        r >= c && push_rc!(r, c)
+    end
+    for nn in 1:N, i in 1:ndeg
+        cc = col_Q_pm(i, nn, J, N, ndeg, R); push_rc!(cc, cc)
+    end
+    for j in 1:J
+        cL = col_L_pm(j, J, N, ndeg, R)
+        push_rc!(cL, col_ur_pm(region[j]))   # (Lj, ur[region])
+        push_rc!(cL, cL)                      # (Lj, Lj)
+    end
+    nt = n_pmob(J, N, ndeg, R)
+    return struct_from_triplets(rows, cols, nt, nt)
+end
+
+# ----- Hessian values (objective linear; obj_factor unused) -----
+function hessian_pmob(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                      obj_factor::Float64, lambda::Vector{Float64},
+                      values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    sigma, beta, a, alpha = param.sigma, param.beta, param.a, param.alpha
+    psigma = (sigma - 1) / sigma
+    region = graph.region
+
+    Cjn = reshape(view(x, R + 1:R + J * N), J, N)
+    Qin = reshape(view(x, R + J * N + 1:R + J * N + ndeg * N), ndeg, N)
+    Lj = view(x, R + J * N + ndeg * N + 1:n_pmob(J, N, ndeg, R))
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+
+    omegaj = lambda[1:J]
+    Pjn = reshape(lambda[J + 1:J + J * N], J, N)
+
+    nt = n_pmob(J, N, ndeg, R)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    @inbounds for j in 1:J
+        up = felicity_c(Cj[j], graph.Hj[j], alpha)
+        us = felicity_cc(Cj[j], graph.Hj[j], alpha)
+        pref = -(omegaj[j] * us * Cj[j]^(2 / sigma) + (1 / sigma) * omegaj[j] * up * Cj[j]^(2 / sigma - 1))
+        for nn in 1:N, nd in 1:N
+            r = col_C_pm(j, nn, J, R); c = col_C_pm(j, nd, J, R)
+            r >= c || continue
+            val = pref * Cjn[j, nn]^(-1 / sigma) * Cjn[j, nd]^(-1 / sigma)
+            if nn == nd
+                val += (1 / sigma) * omegaj[j] * up * Cj[j]^(1 / sigma) * Cjn[j, nn]^(-1 / sigma - 1)
+            end
+            addv!(r, c, val)
+        end
+    end
+    # (Qin, Qin) diagonal: transport-cost curvature, weighted by origin-node price
+    @inbounds for nn in 1:N
+        ApP = Apos' * Pjn[:, nn]; AnP = Aneg' * Pjn[:, nn]
+        for i in 1:ndeg
+            q = Qin[i, nn]; aq = abs(q)
+            wgt = q > 0 ? ApP[i] : AnP[i]
+            hpow = aq == 0.0 ? (beta == 1.0 ? 1.0 : 0.0) : aq^(beta - 1)
+            cc = col_Q_pm(i, nn, J, N, ndeg, R)
+            addv!(cc, cc, (1 + beta) * beta * hpow / kappa_ex[i] * wgt)
+        end
+    end
+    @inbounds for j in 1:J
+        cL = col_L_pm(j, J, N, ndeg, R)
+        addv!(cL, col_ur_pm(region[j]), omegaj[j])
+        hl = 0.0
+        for nn in 1:N
+            hl += -a * (a - 1) * graph.Zjn[j, nn] * Pjn[j, nn] * Lj[j]^(a - 2)
+        end
+        addv!(cL, cL, hl)
+    end
+
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nt, nt)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_pmob(x, mult_g, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    psigma = (param.sigma - 1) / param.sigma
+
+    ur = x[1:R]
+    Cjn = reshape(x[R + 1:R + J * N], J, N)
+    Qin = reshape(x[R + J * N + 1:R + J * N + ndeg * N], ndeg, N)
+    Lj = x[R + J * N + ndeg * N + 1:n_pmob(J, N, ndeg, R)]
+
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    cj = ifelse.(Lj .== 0, 0.0, Cj ./ Lj)
+    hj = ifelse.(Lj .== 0, 0.0, graph.Hj ./ Lj)
+    uj = param.u.(cj, hj)
+    Qjkn = gen_network_flows(Qin, graph, N)
+    Pjn = reshape(mult_g[J + 1:J + J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    return (
+        welfare = sum(graph.omegar .* graph.Lr .* ur),
+        reg_pc_welfare = ur,
+        Yjn = Yjn, Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Cjn, Cj = Cj, Ljn = Ljn, Lj = Lj,
+        cj = cj, hj = hj, uj = uj,
+        Pjn = Pjn, PCj = PCj, Qin = Qin, Qjkn = Qjkn,
+    )
+end

--- a/src/models/solve_allocation_partial_mobility_cgc.jl
+++ b/src/models/solve_allocation_partial_mobility_cgc.jl
@@ -1,0 +1,337 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_partial_mobility_cgc.m: labor
+# mobile within regions, cross-good congestion, Armington (<=1 good per
+# location). As solve_allocation_mobility_cgc but with per-region utility ur and
+# regional labor-resource constraints.
+#
+# Variable layout (x):
+#   x = [ur(R); Cj(J); Djn(J*N); Qin_direct(ndeg*N); Qin_indirect(ndeg*N); Lj(J)]
+# Constraint layout (g):
+#   g = [cons_u(J); cons_C(J); cons_Q(J*N); cons_L(R)]   (R = nregions)
+
+"""
+    solve_allocation_partial_mobility_cgc(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the partial-mobility, cross-good-congestion allocation (Armington) via direct Ipopt.
+"""
+function solve_allocation_partial_mobility_cgc(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_partial_mobility_cgc only supports one good at most per location.")
+    end
+
+    n = R + J + J * N + 2 * ndeg * N + J
+    if x0 === nothing || isempty(x0)
+        counts = zeros(R); for j in 1:J; counts[graph.region[j]] += 1; end
+        Lj0 = [graph.Lr[graph.region[j]] / counts[graph.region[j]] for j in 1:J]
+        x0 = vcat(zeros(R), fill(1e-6 * J, J), fill(1e-6, J * N), fill(1e-6, 2 * ndeg * N), Lj0)
+    end
+
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_pmcgc(auxdata), () -> hessian_structure_pmcgc(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    obj = (x) -> -sum(graph.omegar[r] * graph.Lr[r] * x[r] for r in 1:R)
+    grad = (x, grad_f) -> (fill!(grad_f, 0.0); for r in 1:R; grad_f[r] = -graph.omegar[r] * graph.Lr[r]; end; nothing)
+    cons = (x, g) -> constraints_pmcgc(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_pmcgc(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_pmcgc(x, rows, cols, obj_factor, lambda, values, saux)
+
+    m = J + J + J * N + R
+    x_L = vcat(fill(-Inf, R), fill(1e-6, J), fill(1e-6, J * N), fill(1e-6, 2 * ndeg * N), fill(1e-8, J))
+    x_U = vcat(fill(Inf, R), fill(Inf, J), fill(Inf, J * N), fill(Inf, 2 * ndeg * N), fill(Inf, J))
+    g_L = vcat(fill(-Inf, J + J + J * N), zeros(R))
+    g_U = vcat(fill(0.0, J + J + J * N), zeros(R))
+
+    x, status, mult_g = run_ipopt_primal(cache, :partial_mobility_cgc, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+    results = recover_allocation_pmcgc(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- index helpers -----
+@inline n_pmcgc(J, N, ndeg, R) = R + J + J * N + 2 * ndeg * N + J
+@inline col_ur_pmc(r) = r
+@inline col_Cj_pmc(j, R) = R + j
+@inline col_D_pmc(j, n, J, R) = R + J + (n - 1) * J + j
+@inline col_Qd_pmc(i, n, J, N, ndeg, R) = R + J + J * N + (n - 1) * ndeg + i
+@inline col_Qi_pmc(i, n, J, N, ndeg, R) = R + J + J * N + ndeg * N + (n - 1) * ndeg + i
+@inline col_L_pmc(j, J, N, ndeg, R) = R + J + J * N + 2 * ndeg * N + j
+@inline row_u_pmc(j) = j
+@inline row_C_pmc(j, J) = J + j
+@inline row_Q_pmc(j, n, J) = 2 * J + (n - 1) * J + j
+@inline row_L_pmc(r, J, N) = 2 * J + J * N + r
+
+# ----- constraints -----
+function constraints_pmcgc(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, alpha = param.m, param.nu, param.beta, param.a, param.alpha
+    psigma = (param.sigma - 1) / param.sigma
+    costfac = (beta + 1) / nu
+    region = graph.region
+
+    ur = view(x, 1:R)
+    Cj = view(x, R + 1:R + J)
+    Djn = reshape(view(x, R + J + 1:R + J + J * N), J, N)
+    Qd = reshape(view(x, R + J + J * N + 1:R + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, R + J + J * N + ndeg * N + 1:R + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, R + J + J * N + 2 * ndeg * N + 1:n_pmcgc(J, N, ndeg, R))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2)); Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cost_d = Apos * (Sd .^ costfac ./ kappa_ex); cost_i = Aneg * (Si .^ costfac ./ kappa_ex)
+
+    @inbounds for j in 1:J
+        g[row_u_pmc(j)] = Lj[j] * ur[region[j]] - felicity(Cj[j], graph.Hj[j], alpha)
+        g[row_C_pmc(j, J)] = Cj[j] + cost_d[j] + cost_i[j] - Dj[j]
+    end
+    @inbounds for nn in 1:N
+        netflow = A * Qd[:, nn] - A * Qi[:, nn]
+        for j in 1:J
+            g[row_Q_pmc(j, nn, J)] = Djn[j, nn] + netflow[j] - graph.Zjn[j, nn] * Lj[j]^a
+        end
+    end
+    @inbounds for r in 1:R; g[row_L_pmc(r, J, N)] = -graph.Lr[r]; end
+    @inbounds for j in 1:J; g[row_L_pmc(region[j], J, N)] += Lj[j]; end
+    return
+end
+
+# ----- Jacobian structure -----
+function jacobian_structure_pmcgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; region = graph.region
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    for j in 1:J
+        push_rc!(j, col_ur_pmc(region[j]))
+        push_rc!(j, col_Cj_pmc(j, R))
+        push_rc!(j, col_L_pmc(j, J, N, ndeg, R))
+    end
+    for j in 1:J
+        r = row_C_pmc(j, J)
+        push_rc!(r, col_Cj_pmc(j, R))
+        for nn in 1:N; push_rc!(r, col_D_pmc(j, nn, J, R)); end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0; push_rc!(r, col_Qd_pmc(i, nn, J, N, ndeg, R)); end
+            if A[j, i] < 0; push_rc!(r, col_Qi_pmc(i, nn, J, N, ndeg, R)); end
+        end
+    end
+    for nn in 1:N, j in 1:J
+        r = row_Q_pmc(j, nn, J)
+        push_rc!(r, col_D_pmc(j, nn, J, R))
+        for i in 1:ndeg
+            if A[j, i] != 0
+                push_rc!(r, col_Qd_pmc(i, nn, J, N, ndeg, R))
+                push_rc!(r, col_Qi_pmc(i, nn, J, N, ndeg, R))
+            end
+        end
+        push_rc!(r, col_L_pmc(j, J, N, ndeg, R))
+    end
+    for j in 1:J; push_rc!(row_L_pmc(region[j], J, N), col_L_pmc(j, J, N, ndeg, R)); end
+    return struct_from_triplets(rows, cols, J + J + J * N + R, n_pmcgc(J, N, ndeg, R))
+end
+
+# ----- Jacobian values -----
+function jacobian_pmcgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                        values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, sigma, alpha = param.m, param.nu, param.beta, param.a, param.sigma, param.alpha
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+    region = graph.region
+
+    ur = view(x, 1:R)
+    Cj = view(x, R + 1:R + J)
+    Djn = reshape(view(x, R + J + 1:R + J + J * N), J, N)
+    Qd = reshape(view(x, R + J + J * N + 1:R + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, R + J + J * N + ndeg * N + 1:R + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, R + J + J * N + 2 * ndeg * N + 1:n_pmcgc(J, N, ndeg, R))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2)); Si = vec(sum((Qi .^ nu) .* m', dims=2))
+    cpos = Sd .^ (costfac - 1) ./ kappa_ex; cneg = Si .^ (costfac - 1) ./ kappa_ex
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+    @inbounds for j in 1:J
+        addv!(j, col_ur_pmc(region[j]), Lj[j])
+        addv!(j, col_Cj_pmc(j, R), -felicity_c(Cj[j], graph.Hj[j], alpha))
+        addv!(j, col_L_pmc(j, J, N, ndeg, R), ur[region[j]])
+    end
+    @inbounds for j in 1:J
+        r = row_C_pmc(j, J)
+        addv!(r, col_Cj_pmc(j, R), 1.0)
+        for nn in 1:N
+            addv!(r, col_D_pmc(j, nn, J, R), -Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma))
+        end
+        for nn in 1:N, i in 1:ndeg
+            if A[j, i] > 0
+                addv!(r, col_Qd_pmc(i, nn, J, N, ndeg, R), Apos[j, i] * (1 + beta) * cpos[i] * m[nn] * Qd[i, nn]^(nu - 1))
+            end
+            if A[j, i] < 0
+                addv!(r, col_Qi_pmc(i, nn, J, N, ndeg, R), Aneg[j, i] * (1 + beta) * cneg[i] * m[nn] * Qi[i, nn]^(nu - 1))
+            end
+        end
+    end
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_pmc(j, nn, J)
+        addv!(r, col_D_pmc(j, nn, J, R), 1.0)
+        for i in 1:ndeg
+            if A[j, i] != 0
+                addv!(r, col_Qd_pmc(i, nn, J, N, ndeg, R), A[j, i])
+                addv!(r, col_Qi_pmc(i, nn, J, N, ndeg, R), -A[j, i])
+            end
+        end
+        addv!(r, col_L_pmc(j, J, N, ndeg, R), -a * graph.Zjn[j, nn] * Lj[j]^(a - 1))
+    end
+    @inbounds for j in 1:J; addv!(row_L_pmc(region[j], J, N), col_L_pmc(j, J, N, ndeg, R), 1.0); end
+
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J + J + J * N + R, n_pmcgc(J, N, ndeg, R))
+    return
+end
+
+# ----- Hessian structure -----
+function hessian_structure_pmcgc(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    region = graph.region
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    for j in 1:J; push_rc!(col_Cj_pmc(j, R), col_Cj_pmc(j, R)); end
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_D_pmc(j, nn, J, R); c = col_D_pmc(j, nd, J, R); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qd_pmc(i, nn, J, N, ndeg, R); c = col_Qd_pmc(i, nd, J, N, ndeg, R); r >= c && push_rc!(r, c)
+    end
+    for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qi_pmc(i, nn, J, N, ndeg, R); c = col_Qi_pmc(i, nd, J, N, ndeg, R); r >= c && push_rc!(r, c)
+    end
+    for j in 1:J
+        cL = col_L_pmc(j, J, N, ndeg, R)
+        push_rc!(cL, col_ur_pmc(region[j]))   # (Lj, ur[region])
+        push_rc!(cL, cL)                        # (Lj, Lj)
+    end
+    nt = n_pmcgc(J, N, ndeg, R)
+    return struct_from_triplets(rows, cols, nt, nt)
+end
+
+# ----- Hessian values (objective linear) -----
+function hessian_pmcgc(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                       obj_factor::Float64, lambda::Vector{Float64},
+                       values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    m, nu, beta, a, sigma, alpha = param.m, param.nu, param.beta, param.a, param.sigma, param.alpha
+    psigma = (sigma - 1) / sigma
+    costfac = (beta + 1) / nu
+    region = graph.region
+
+    Cj = view(x, R + 1:R + J)
+    Djn = reshape(view(x, R + J + 1:R + J + J * N), J, N)
+    Qd = reshape(view(x, R + J + J * N + 1:R + J + J * N + ndeg * N), ndeg, N)
+    Qi = reshape(view(x, R + J + J * N + ndeg * N + 1:R + J + J * N + 2 * ndeg * N), ndeg, N)
+    Lj = view(x, R + J + J * N + 2 * ndeg * N + 1:n_pmcgc(J, N, ndeg, R))
+    Dj = _Dj_cgc(Djn, psigma)
+    Sd = vec(sum((Qd .^ nu) .* m', dims=2)); Si = vec(sum((Qi .^ nu) .* m', dims=2))
+
+    omega = lambda[1:J]
+    lamC = lambda[J + 1:2 * J]
+    Pjn = reshape(lambda[2 * J + 1:2 * J + J * N], J, N)
+    lamApos = Apos' * lamC; lamAneg = Aneg' * lamC
+
+    nt = n_pmcgc(J, N, ndeg, R)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    @inbounds for j in 1:J
+        addv!(col_Cj_pmc(j, R), col_Cj_pmc(j, R), -omega[j] * felicity_cc(Cj[j], graph.Hj[j], alpha))
+    end
+    @inbounds for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_D_pmc(j, nn, J, R); c = col_D_pmc(j, nd, J, R); r >= c || continue
+        val = -lamC[j] / sigma * Dj[j]^(-(sigma - 2) / sigma) * Djn[j, nn]^(-1 / sigma) * Djn[j, nd]^(-1 / sigma)
+        nn == nd && (val += lamC[j] / sigma * Dj[j]^(1 / sigma) * Djn[j, nn]^(-1 / sigma - 1))
+        addv!(r, c, val)
+    end
+    @inbounds for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qd_pmc(i, nn, J, N, ndeg, R); c = col_Qd_pmc(i, nd, J, N, ndeg, R); r >= c || continue
+        val = (1 + beta) * (costfac - 1) * nu * lamApos[i] * Sd[i]^(costfac - 2) / kappa_ex[i] *
+              m[nn] * Qd[i, nn]^(nu - 1) * m[nd] * Qd[i, nd]^(nu - 1)
+        (nn == nd && nu > 1) && (val += (1 + beta) * (nu - 1) * lamApos[i] * Sd[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qd[i, nn]^(nu - 2))
+        addv!(r, c, val)
+    end
+    @inbounds for i in 1:ndeg, nn in 1:N, nd in 1:N
+        r = col_Qi_pmc(i, nn, J, N, ndeg, R); c = col_Qi_pmc(i, nd, J, N, ndeg, R); r >= c || continue
+        val = (1 + beta) * (costfac - 1) * nu * lamAneg[i] * Si[i]^(costfac - 2) / kappa_ex[i] *
+              m[nn] * Qi[i, nn]^(nu - 1) * m[nd] * Qi[i, nd]^(nu - 1)
+        (nn == nd && nu > 1) && (val += (1 + beta) * (nu - 1) * lamAneg[i] * Si[i]^(costfac - 1) / kappa_ex[i] * m[nn] * Qi[i, nn]^(nu - 2))
+        addv!(r, c, val)
+    end
+    @inbounds for j in 1:J
+        cL = col_L_pmc(j, J, N, ndeg, R)
+        addv!(cL, col_ur_pmc(region[j]), omega[j])
+        hll = 0.0
+        for nn in 1:N
+            hll += -a * (a - 1) * Pjn[j, nn] * graph.Zjn[j, nn] * Lj[j]^(a - 2)
+        end
+        addv!(cL, cL, hll)
+    end
+
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nt, nt)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_pmcgc(x, mult_g, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg, R = graph.J, param.N, graph.ndeg, graph.nregions
+    psigma = (param.sigma - 1) / param.sigma
+
+    ur = x[1:R]
+    Cj = x[R + 1:R + J]
+    Djn = max.(0.0, reshape(x[R + J + 1:R + J + J * N], J, N))
+    Qd = reshape(x[R + J + J * N + 1:R + J + J * N + ndeg * N], ndeg, N)
+    Qi = reshape(x[R + J + J * N + ndeg * N + 1:R + J + J * N + 2 * ndeg * N], ndeg, N)
+    Lj = x[R + J + J * N + 2 * ndeg * N + 1:n_pmcgc(J, N, ndeg, R)]
+    Dj = _Dj_cgc(Djn, psigma)
+    cj = ifelse.(Lj .== 0, 0.0, Cj ./ Lj)
+    hj = ifelse.(Lj .== 0, 0.0, graph.Hj ./ Lj)
+    uj = param.u.(cj, hj)
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    Qin = Qd - Qi
+    Qjkn = gen_network_flows(Qin, graph, N)
+    Pjn = reshape(mult_g[2 * J + 1:2 * J + J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    return (
+        welfare = sum(graph.omegar .* graph.Lr .* ur),
+        reg_pc_welfare = ur,
+        Yjn = Yjn, Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Djn, Cj = Cj, Djn = Djn, Dj = Dj, Ljn = Ljn, Lj = Lj,
+        cj = cj, hj = hj, uj = uj,
+        Pjn = Pjn, PCj = PCj, Qin = Qin, Qjkn = Qjkn,
+    )
+end

--- a/src/models/solve_allocation_primal.jl
+++ b/src/models/solve_allocation_primal.jl
@@ -1,0 +1,271 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# by P. Fajgelbaum, E. Schaal, D. Henricot, C. Mantovani 2017-19
+# ================================================ version 1.0.4
+#
+# Direct-Ipopt port of MATLAB solve_allocation_primal.m: fixed labor, no
+# cross-good congestion, Armington (<=1 good per location). Used when the dual
+# is unavailable (beta > 1, where the dual is not twice differentiable, or
+# duality disabled). Single signed flow Qin; labor fixed at graph.Lj.
+#
+# Variable layout (x):
+#   x = [Cjn(J*N); Qin(ndeg*N)]
+# Constraint layout (g):
+#   g = [cons_Q(J*N)]   (balanced flows only)
+
+"""
+    solve_allocation_primal(x0, auxdata, verbose=true) -> (results::Dict, status, x)
+
+Solve the fixed-labor, no-congestion allocation (Armington) via direct Ipopt
+(primal). Used when the dual approach is not available.
+"""
+function solve_allocation_primal(x0, auxdata, verbose=true)
+    graph = auxdata.graph
+    param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+
+    if any(vec(sum(graph.Zjn .> 0, dims=2)) .> 1)
+        error("solve_allocation_primal only supports one good at most per location.")
+    end
+
+    n = J * N + ndeg * N
+    if x0 === nothing || isempty(x0)
+        x0 = vcat(fill(1e-6, J * N), zeros(ndeg * N))
+    end
+
+    cache = get(auxdata, :struct_cache, nothing)
+    js, hs = get_structs(auxdata, () -> jacobian_structure_primal(auxdata), () -> hessian_structure_primal(auxdata))
+    saux = (auxdata..., jac_struct = js, hess_struct = hs)
+    nnz_jac = length(js[1])
+    nnz_hess = length(hs[1])
+
+    obj = (x) -> objective_primal(x, saux)
+    grad = (x, grad_f) -> gradient_primal(x, grad_f, saux)
+    cons = (x, g) -> constraints_primal(x, g, saux)
+    jac = (x, rows, cols, values) -> jacobian_primal(x, rows, cols, values, saux)
+    hess = (x, rows, cols, obj_factor, lambda, values) -> hessian_primal(x, rows, cols, obj_factor, lambda, values, saux)
+
+    m = J * N
+    x_L = vcat(fill(1e-8, J * N), fill(-Inf, ndeg * N))
+    x_U = vcat(fill(Inf, J * N), fill(Inf, ndeg * N))
+    g_L = fill(-Inf, J * N)
+    g_U = fill(0.0, J * N)
+
+    x, status, mult_g = run_ipopt_primal(cache, :primal, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                                         obj, cons, grad, jac, hess, x0, param, verbose)
+    results = recover_allocation_primal(x, mult_g, auxdata)
+    return namedtuple_to_dict(results), status, x
+end
+
+# ----- index helpers -----
+@inline n_primal(J, N, ndeg) = J * N + ndeg * N
+@inline col_C_pr(j, n, J) = (n - 1) * J + j
+@inline col_Q_pr(i, n, J, N, ndeg) = J * N + (n - 1) * ndeg + i
+@inline row_Q_pr(j, n, J) = (n - 1) * J + j
+
+# helper: aggregate consumption Cj and per-capita cj
+function _cj_primal(Cjn, graph, psigma)
+    Cj = dropdims(sum(Cjn .^ psigma, dims=2), dims=2) .^ (1 / psigma)
+    cj = ifelse.(graph.Lj .== 0, 0.0, Cj ./ graph.Lj)
+    return Cj, cj
+end
+
+# ----- objective (nonlinear): f = -sum omegaj*Lj*u(cj,hj) -----
+function objective_primal(x, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N = graph.J, param.N
+    psigma = (param.sigma - 1) / param.sigma
+    Cjn = reshape(view(x, 1:J * N), J, N)
+    _, cj = _cj_primal(Cjn, graph, psigma)
+    return -sum(graph.omegaj .* graph.Lj .* param.u.(cj, graph.hj))
+end
+
+function gradient_primal(x::Vector{Float64}, grad_f::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N = graph.J, param.N
+    sigma = param.sigma
+    psigma = (sigma - 1) / sigma
+    Cjn = reshape(view(x, 1:J * N), J, N)
+    Cj, cj = _cj_primal(Cjn, graph, psigma)
+    fill!(grad_f, 0.0)
+    @inbounds for nn in 1:N, j in 1:J
+        grad_f[col_C_pr(j, nn, J)] = -graph.omegaj[j] * param.uprime(cj[j], graph.hj[j]) *
+                                     Cjn[j, nn]^(-1 / sigma) * Cj[j]^(1 / sigma)
+    end
+    return
+end
+
+# ----- constraints (single signed Qin, cost charged at origin) -----
+function constraints_primal(x::Vector{Float64}, g::Vector{Float64}, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    psigma = (param.sigma - 1) / param.sigma
+    beta, a = param.beta, param.a
+    Cjn = reshape(view(x, 1:J * N), J, N)
+    Qin = reshape(view(x, J * N + 1:J * N + ndeg * N), ndeg, N)
+
+    @inbounds for nn in 1:N
+        q = Qin[:, nn]
+        cost = abs.(q) .^ (1 + beta) ./ kappa_ex
+        pos = q .> 0
+        cost_at = Apos * (cost .* pos) + Aneg * (cost .* .!pos)
+        flow = A * q + cost_at
+        for j in 1:J
+            g[row_Q_pr(j, nn, J)] = Cjn[j, nn] + flow[j] - graph.Zjn[j, nn] * graph.Lj[j]^a
+        end
+    end
+    return
+end
+
+# ----- Jacobian structure -----
+function jacobian_structure_primal(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    for nn in 1:N, j in 1:J
+        r = row_Q_pr(j, nn, J)
+        push_rc!(r, col_C_pr(j, nn, J))
+        for i in 1:ndeg
+            A[j, i] != 0 && push_rc!(r, col_Q_pr(i, nn, J, N, ndeg))
+        end
+    end
+    return struct_from_triplets(rows, cols, J * N, n_primal(J, N, ndeg))
+end
+
+# ----- Jacobian values -----
+function jacobian_primal(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                         values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.jac_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    A = auxdata.edges.A; Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    beta = param.beta
+    Qin = reshape(view(x, J * N + 1:J * N + ndeg * N), ndeg, N)
+
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (push!(Ir, r); push!(Jc, c); push!(V, v))
+    @inbounds for nn in 1:N, j in 1:J
+        r = row_Q_pr(j, nn, J)
+        addv!(r, col_C_pr(j, nn, J), 1.0)
+        for i in 1:ndeg
+            if A[j, i] != 0
+                q = Qin[i, nn]
+                Morig = q > 0 ? Apos[j, i] : Aneg[j, i]
+                dcost = (1 + beta) * Morig * sign(q) * abs(q)^beta / kappa_ex[i]
+                addv!(r, col_Q_pr(i, nn, J, N, ndeg), A[j, i] + dcost)
+            end
+        end
+    end
+    fill_values_from_triplets!(values, auxdata.jac_struct, Ir, Jc, V, J * N, n_primal(J, N, ndeg))
+    return
+end
+
+# ----- Hessian structure -----
+function hessian_structure_primal(auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    rows = Int[]; cols = Int[]
+    push_rc!(r, c) = (push!(rows, r); push!(cols, c))
+    # Cjn block: same-location coupling across goods (lower triangle)
+    for j in 1:J, nn in 1:N, nd in 1:N
+        r = col_C_pr(j, nn, J); c = col_C_pr(j, nd, J)
+        r >= c && push_rc!(r, c)
+    end
+    # Qin diagonal
+    for nn in 1:N, i in 1:ndeg
+        cc = col_Q_pr(i, nn, J, N, ndeg); push_rc!(cc, cc)
+    end
+    nt = n_primal(J, N, ndeg)
+    return struct_from_triplets(rows, cols, nt, nt)
+end
+
+# ----- Hessian values: objective part (obj_factor) + constraint part (lambda) -----
+function hessian_primal(x::Vector{Float64}, rows::Vector{Int32}, cols::Vector{Int32},
+                        obj_factor::Float64, lambda::Vector{Float64},
+                        values::Union{Nothing,Vector{Float64}}, auxdata)
+    if values === nothing
+        r, c = auxdata.hess_struct; rows .= r; cols .= c; return
+    end
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    Apos = auxdata.edges.Apos; Aneg = auxdata.edges.Aneg
+    kappa_ex = auxdata.kappa_ex
+    sigma, beta = param.sigma, param.beta
+    psigma = (sigma - 1) / sigma
+    Cjn = reshape(view(x, 1:J * N), J, N)
+    Qin = reshape(view(x, J * N + 1:J * N + ndeg * N), ndeg, N)
+    Cj, cj = _cj_primal(Cjn, graph, psigma)
+    Pjn = reshape(lambda[1:J * N], J, N)
+
+    nt = n_primal(J, N, ndeg)
+    Ir = Int[]; Jc = Int[]; V = Float64[]
+    addv!(r, c, v) = (r >= c && (push!(Ir, r); push!(Jc, c); push!(V, v)))
+
+    # Cjn block (objective, weighted by obj_factor)
+    @inbounds for j in 1:J
+        up = param.uprime(cj[j], graph.hj[j])
+        us = param.usecond(cj[j], graph.hj[j])
+        # off-diagonal prefactor (same location, across goods)
+        pref = -obj_factor * graph.omegaj[j] *
+               ((1 / sigma) * up * Cj[j]^(2 / sigma - 1) + (1 / graph.Lj[j]) * us * Cj[j]^(2 / sigma))
+        for nn in 1:N, nd in 1:N
+            r = col_C_pr(j, nn, J); c = col_C_pr(j, nd, J)
+            r >= c || continue
+            val = pref * Cjn[j, nn]^(-1 / sigma) * Cjn[j, nd]^(-1 / sigma)
+            if nn == nd
+                val += obj_factor * (1 / sigma) * Cjn[j, nn]^(-1 / sigma - 1) *
+                       graph.omegaj[j] * Cj[j]^(1 / sigma) * up
+            end
+            addv!(r, c, val)
+        end
+    end
+    # Qin diagonal (constraint, weighted by lambda=Pjn; only if beta>0)
+    if beta > 0
+        @inbounds for nn in 1:N
+            ApP = Apos' * Pjn[:, nn]; AnP = Aneg' * Pjn[:, nn]
+            for i in 1:ndeg
+                q = Qin[i, nn]; aq = abs(q)
+                wgt = q > 0 ? ApP[i] : AnP[i]
+                hpow = aq == 0.0 ? (beta == 1.0 ? 1.0 : 0.0) : aq^(beta - 1)
+                cc = col_Q_pr(i, nn, J, N, ndeg)
+                addv!(cc, cc, (1 + beta) * beta * hpow / kappa_ex[i] * wgt)
+            end
+        end
+    end
+    fill_values_from_triplets!(values, auxdata.hess_struct, Ir, Jc, V, nt, nt)
+    return
+end
+
+# ----- recover allocation -----
+function recover_allocation_primal(x, mult_g, auxdata)
+    graph = auxdata.graph; param = auxdata.param
+    J, N, ndeg = graph.J, param.N, graph.ndeg
+    psigma = (param.sigma - 1) / param.sigma
+
+    Cjn = reshape(x[1:J * N], J, N)
+    Qin = reshape(x[J * N + 1:J * N + ndeg * N], ndeg, N)
+    Cj, cj = _cj_primal(Cjn, graph, psigma)
+    Lj = graph.Lj
+    Ljn = (graph.Zjn .> 0) .* Lj
+    Yjn = graph.Zjn .* Lj .^ param.a
+    hj = ifelse.(Lj .== 0, 0.0, graph.Hj ./ Lj)
+    uj = param.u.(cj, hj)
+    Qjkn = gen_network_flows(Qin, graph, N)
+    Pjn = reshape(mult_g[1:J * N], J, N)
+    PCj = dropdims(sum(Pjn .^ (1 - param.sigma), dims=2), dims=2) .^ (1 / (1 - param.sigma))
+
+    return (
+        welfare = sum(graph.omegaj .* Lj .* param.u.(cj, graph.hj)),
+        Yjn = Yjn, Yj = dropdims(sum(Yjn, dims=2), dims=2),
+        Cjn = Cjn, Cj = Cj, Ljn = Ljn, Lj = Lj,
+        cj = cj, hj = hj, uj = uj,
+        Pjn = Pjn, PCj = PCj, Qin = Qin, Qjkn = Qjkn,
+    )
+end

--- a/src/models/solve_allocation_primal_helpers.jl
+++ b/src/models/solve_allocation_primal_helpers.jl
@@ -1,0 +1,124 @@
+# ==============================================================
+# OPTIMAL TRANSPORT NETWORKS IN SPATIAL EQUILIBRIUM
+# Shared helpers for the direct-Ipopt primal solvers
+# ==============================================================
+#
+# These back the hand-coded primal allocation solvers (solve_allocation_mobility,
+# _cgc, _partial_mobility, _primal, ...) that call Ipopt's C interface directly,
+# mirroring the dual solvers but with constraints.
+
+# Cobb-Douglas felicity W(c,h) = (c/alpha)^alpha * (h/(1-alpha))^(1-alpha) and its
+# first/second derivatives w.r.t. c. The mobility and partial-mobility utility
+# constraints use this felicity directly (the rho = 0 form), independent of
+# param.rho, so the solvers call these rather than param.uprime / param.usecond.
+@inline felicity(c, h, alpha) = (c / alpha)^alpha * (h / (1 - alpha))^(1 - alpha)
+@inline felicity_c(c, h, alpha) = (c / alpha)^(alpha - 1) * (h / (1 - alpha))^(1 - alpha)
+@inline felicity_cc(c, h, alpha) = (alpha - 1) / alpha * (c / alpha)^(alpha - 2) * (h / (1 - alpha))^(1 - alpha)
+
+# Fetch the Jacobian/Hessian sparsity structures, computing them once and caching them when
+# optimal_network supplies a per-run `struct_cache`. The structures depend only on the graph
+# (not on kappa or x), so this avoids rebuilding them on every outer iteration's solve.
+# `jacf`/`hessf` are zero-arg closures that compute the respective structure.
+function get_structs(auxdata, jacf, hessf)
+    if haskey(auxdata, :struct_cache)
+        c = auxdata.struct_cache
+        return get!(jacf, c, :jac), get!(hessf, c, :hess)
+    end
+    return jacf(), hessf()
+end
+
+# Build the deduplicated, column-major (rows, cols) sparsity structure from triplet
+# lists, plus a map from column-major linear index -> position in (rows, cols). The
+# map lets the value callbacks scatter their entries onto the declared structure
+# WITHOUT building a sparse matrix inside the Ipopt C callback (allocating a sparse
+# matrix from within the @cfunction trampoline corrupts the heap). Returns
+# (rows::Vector{Int32}, cols::Vector{Int32}, lin2pos::Dict{Int,Int}).
+function struct_from_triplets(rows, cols, m, n)
+    nt = length(rows)
+    lin = Vector{Int}(undef, nt)
+    @inbounds for t in 1:nt
+        lin[t] = (Int(cols[t]) - 1) * m + Int(rows[t])
+    end
+    order = sortperm(lin)   # column-major order
+    r_out = Int32[]; c_out = Int32[]
+    lin2pos = Dict{Int,Int}()
+    last = -1
+    @inbounds for t in order
+        if lin[t] != last
+            push!(r_out, rows[t]); push!(c_out, cols[t])
+            lin2pos[lin[t]] = length(r_out)
+            last = lin[t]
+        end
+    end
+    return (r_out, c_out, lin2pos)
+end
+
+# Scatter triplet values (Ir, Jc, V; overlapping entries sum) onto the values buffer
+# in the order of the precomputed structure, using the linear-index -> position map.
+# No sparse-matrix allocation (heap-safe inside the Ipopt callback).
+function fill_values_from_triplets!(values, struct_rc, Ir, Jc, V, m, n)
+    lin2pos = struct_rc[3]
+    fill!(values, 0.0)
+    @inbounds for t in eachindex(V)
+        values[lin2pos[(Int(Jc[t]) - 1) * m + Int(Ir[t])]] += V[t]
+    end
+    return
+end
+
+# Create, configure, and solve an Ipopt problem via the C interface, REUSING the
+# problem object across outer iterations when a per-run `cache` is supplied (keyed by
+# `key`). On the first call the problem is built and stored together with its stable
+# auxdata `saux` (whose `kappa_ex` the callbacks captured); on later calls only
+# `saux.kappa_ex` is updated in place and the solver re-runs warm-started from the
+# previous primal+dual solution. This avoids rebuilding the problem and the cold dual
+# restart each iteration — the same trick JuMP uses by reusing its model.
+#
+# `saux` is the stable auxdata the callbacks (obj/cons/grad/jac/hess) capture. Returns
+# (x, status, mult_g); the recover functions only need graph/param/x/mult_g, so callers
+# pass their original auxdata to recover (its kappa is irrelevant there).
+function run_ipopt_primal(cache, key, saux, n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+                          obj, cons, grad, jac, hess, x0, param, verbose; max_iter=2000)
+    if cache !== nothing && haskey(cache, key)
+        prob, saux0 = cache[key]
+        saux0.kappa_ex .= saux.kappa_ex      # propagate the updated network to the cached callbacks
+        if isempty(x0)
+            Ipopt.AddIpoptStrOption(prob, "warm_start_init_point", "no")  # cold restart requested
+        else
+            prob.x = x0
+            Ipopt.AddIpoptStrOption(prob, "warm_start_init_point", "yes") # reuse previous primal+dual point
+        end
+        status = Ipopt.IpoptSolve(prob)
+        return prob.x, status, prob.mult_g
+    end
+
+    prob = Ipopt.CreateIpoptProblem(
+        n, x_L, x_U, m, g_L, g_U, nnz_jac, nnz_hess,
+        obj, cons, grad, jac, hess
+    )
+    Ipopt.AddIpoptStrOption(prob, "hessian_approximation", "exact")
+    Ipopt.AddIpoptIntOption(prob, "max_iter", max_iter)
+    Ipopt.AddIpoptIntOption(prob, "print_level", verbose ? 5 : 0)
+    # Tight warm-start pushes so reused solves start essentially at the previous point.
+    Ipopt.AddIpoptNumOption(prob, "warm_start_bound_push", 1e-9)
+    Ipopt.AddIpoptNumOption(prob, "warm_start_mult_bound_push", 1e-9)
+    Ipopt.AddIpoptNumOption(prob, "warm_start_bound_frac", 1e-9)
+
+    if haskey(param, :optimizer_attr)
+        for (k, value) in param.optimizer_attr
+            if value isa String
+                Ipopt.AddIpoptStrOption(prob, String(k), value)
+            elseif value isa Float64
+                Ipopt.AddIpoptNumOption(prob, String(k), value)
+            elseif value isa Integer
+                Ipopt.AddIpoptIntOption(prob, String(k), value)
+            end
+        end
+    end
+
+    prob.x = x0
+    status = Ipopt.IpoptSolve(prob)
+    if cache !== nothing
+        cache[key] = (prob, saux)
+    end
+    return prob.x, status, prob.mult_g
+end


### PR DESCRIPTION
## Summary

Adds **direct-Ipopt** primal allocation solvers and makes them the default path for all **Armington** cases (≤1 good produced per location), replacing the JuMP models that previously handled them. This mirrors the original MATLAB toolbox, which calls Ipopt directly with hand-coded sparse derivatives, and extends the approach already used by the dual solvers (`solve_allocation_by_duality*`) to every primal case.

This is the **v0.3.0** release.

## What's new

- **Six new direct solvers**, one per `(mobility × cong)`, each calling Ipopt's C interface directly with analytic sparse gradients / Jacobians / Hessians:
  - `solve_allocation_mobility(_cgc)` — full labor mobility
  - `solve_allocation_partial_mobility(_cgc)` — partial mobility
  - `solve_allocation_cgc`, `solve_allocation_primal` — fixed labor, `beta > 1`
  - Shared machinery in `solve_allocation_primal_helpers.jl` (`run_ipopt_primal`, sparse-structure precompute + value scatter, Cobb-Douglas felicity helpers).
- **JuMP is now an opt-in fallback** — pass `jump = true` to `init_parameters`. The general, non-Armington case (a location producing ≥2 goods) is not covered by the hand-coded solvers and always uses JuMP, regardless of the switch. The fixed-labor `beta ≤ 1` case keeps the faster **dual** path.
- **Performance:** the Ipopt problem (and its sparsity structure) is built once and reused warm-started across the network-design iterations. Combined with analytic derivatives, the direct path is several× to an order of magnitude faster than JuMP at realistic graph sizes (e.g. on an 81-node graph: full mobility ~3.8×, fixed `beta>1` ~9×, partial mobility ~10×, fixed cgc ~15×, mobility+cgc ~64×), and the gap widens with graph size.

## Fixes

- Latent `init_parameters` bug: the utility-function closures captured `rho` before it was zeroed for full labor mobility (affected reported per-location utility `uj`, not welfare).
- `Manifest.toml` regenerated for Julia ≥ 1.12 (Ipopt 1.15 / OpenBLAS 0.3.33), fixing OpenBLAS segfaults on larger problems that also affected the JuMP path.

## Validation

Each direct solver was validated against its JuMP counterpart (finite-difference checks on the analytic Jacobian/Hessian at random interior points; full-pipeline welfare/`Pjn`/`Qjkn`/`Ijk` agreement). Final integrity run (direct vs JuMP relative welfare): mobility 2.2e-05, mobility_cgc 2.1e-05, fixed primal 7.9e-16, fixed cgc 1.9e-06, partial mobility ~1e-7, partial mobility cgc 1.5e-05.

See `NEWS.md` for the user-facing changelog and `CLAUDE.md` for the dispatch/architecture details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)