### PR TITLE
Fix add_node/remove_node and square/triangle delta type (v0.3.1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# 0.3.1
+
+Bug fixes found in a review of the core code against the reference MATLAB toolbox (`misc/matlab/`):
+
+* **`add_node()` and `remove_node()` were completely broken.** Both functions referenced undefined variables (`dict`/`namedtuple`) when copying the input graph and threw `UndefVarError` on any call. They now correctly copy the passed `graph` (matching the MATLAB `add_node.m`/`remove_node.m`), so nodes can again be added to / removed from a graph.
+
+* **`create_graph(..., type = "square")` and `type = "triangle")` returned `delta_i`/`delta_tau` as a `BitMatrix`** (built with `falses`) instead of a `Float64` matrix. This raised an `InexactError` when `apply_geography()` tried to write real-valued building/traversal costs onto such a graph (elevation or obstacle costs). The two constructors now build the cost matrix with `zeros` like `create_map`/`create_custom` and the reference MATLAB `create_graph.m` (which uses `zeros(J,J)` for every graph type), so `apply_geography()` works on all graph types.
+
 # 0.3.0
 
 ## Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransportNetworks"
 uuid = "e2b46e68-897f-4e4e-ba36-a93c9789fd96"
 authors = ["Sebastian Krantz <sebastian.krantz@graduateinstitute.ch>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"

--- a/src/main/create_graph.jl
+++ b/src/main/create_graph.jl
@@ -267,7 +267,7 @@ function create_triangle(w, h)
 
     nodes = [Vector{Int64}() for _ in 1:J]
 
-    delta = falses(J, J)
+    delta = zeros(J, J)
     x = zeros(J) # Needs to be Float64
     y = zeros(Int64, J)
     for j in 1:rows_outer
@@ -366,7 +366,7 @@ function create_square(w, h)
     J = w * h
     nodes = [Vector{Int64}() for _ in 1:J]
 
-    delta = falses(J, J)
+    delta = zeros(J, J)
     x = zeros(Int64, J)
     y = zeros(Int64, J)
     for i in 1:J

--- a/src/main/nodes.jl
+++ b/src/main/nodes.jl
@@ -17,9 +17,9 @@ The new node is given population 1e-6 and productivity equal to the minimum prod
 function add_node(graph, x, y, neighbors)
 
     if graph isa Dict
-        graph_new = copy(dict)
+        graph_new = copy(graph)
     else
-        graph_new = Dict(pairs(namedtuple))
+        graph_new = Dict(pairs(graph))
     end
 
     # Check validity of neighbors list
@@ -126,9 +126,9 @@ Removes node i from the graph, returning an updated `graph` object.
 function remove_node(graph, i)
 
     if graph isa Dict
-        graph_new = copy(dict)
+        graph_new = copy(graph)
     else
-        graph_new = Dict(pairs(namedtuple))
+        graph_new = Dict(pairs(graph))
     end
 
     if i < 1 || i > graph[:J] || i != floor(i)


### PR DESCRIPTION
Two latent bugs found reviewing src/main against the reference MATLAB toolbox (misc/matlab/):

- add_node/remove_node referenced undefined `dict`/`namedtuple` when copying the input graph, throwing UndefVarError on every call. Now copy the passed `graph`, matching add_node.m/remove_node.m.

- create_graph type="square"/"triangle" built delta_i/delta_tau as a BitMatrix (falses), causing InexactError in apply_geography when writing real-valued elevation/obstacle costs. Now use zeros(J,J) like create_map/create_custom and MATLAB create_graph.m.