### PR TITLE
Fix annealing all-NaN network on graphs with zero-cost (delta_i == 0) edges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.2
+
+* **Simulated annealing crashed (all-`NaN` network) whenever the graph has an edge with zero building cost (`delta_i == 0`).** The network-deepening step inside `annealing()` computes `I1 = (delta_tau ./ delta_i .* PQ) .^ (1/(1+gamma))` and then rescales it with `I1 *= K / sum(delta_i .* I1)`. On an edge with `delta_i == 0` the first term is `Inf` (or `NaN`), and `sum(delta_i .* I1)` then contains `0 * Inf = NaN`, which the rescale multiplies across the **entire** `I1` matrix — turning every entry into `NaN` and making the next allocation solve fail (`return flag = -13`, `welfare = 0`). `optimal_network()`'s own FOC step guards against exactly this with `I1[PQ .== 0] .= 0` and `I1[graph.delta_i .== 0] .= 0`, but the two deepening blocks in `annealing.jl` had these two lines commented out. They are now restored, so annealing works on networks with free-to-build (already-maxed) edges. This surfaced on the CEMAC road network (10 edges already at ≥90 km/h have `delta_i = 0`) with `cross_good_congestion = false, annealing = true`.
+
 # 0.3.1
 
 Bug fixes found in a review of the core code against the reference MATLAB toolbox (`misc/matlab/`):

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransportNetworks"
 uuid = "e2b46e68-897f-4e4e-ba36-a93c9789fd96"
 authors = ["Sebastian Krantz <sebastian.krantz@graduateinstitute.ch>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"

--- a/src/main/annealing.jl
+++ b/src/main/annealing.jl
@@ -223,8 +223,8 @@ function annealing(param, graph, I0; kwargs...)
                 
                 I1 = (graph.delta_tau ./ graph.delta_i .* PQ) .^ (1 / (1 + param.gamma))
                 I1[graph.adjacency .== 0] .= 0
-                # I1[PQ .== 0] .= 0
-                # I1[graph.delta_i .== 0] .= 0
+                I1[PQ .== 0] .= 0
+                I1[graph.delta_i .== 0] .= 0
                 I1 *= param.K / sum(graph.delta_i .* I1)
                 I1 = rescale_network!(param, graph, I1, Il, Iu)
                 # Print a message if I1 has any missing, negative or infinite values
@@ -319,8 +319,8 @@ function annealing(param, graph, I0; kwargs...)
         
         I1 = (graph.delta_tau ./ graph.delta_i .* PQ) .^ (1 / (1 + param.gamma))
         I1[graph.adjacency .== 0] .= 0
-        # I1[PQ .== 0] .= 0
-        # I1[graph.delta_i .== 0] .= 0
+        I1[PQ .== 0] .= 0
+        I1[graph.delta_i .== 0] .= 0
         I1 *= param.K / sum(graph.delta_i .* I1)
         I1 = rescale_network!(param, graph, I1, Il, Iu)
         # Print a message if I1 has any missing, negative or infinite values


### PR DESCRIPTION
## Problem

Running simulated annealing on the **CEMAC** road network with `cross_good_congestion = false, annealing = true` collapses: the FOC deepening prints `I1 has 38416 missing` (38416 = 196²), every subsequent inner solve fails with Ipopt `return flag = -13`, and welfare drops to `0.0`.

```
Perturbating network (Temperature=100.0)...
Iterating on FOCs...
I1 has 38416 missing, 0 negative and 0 infinite values
optimization failed! k=1, return flag=-13
Iteration No.1, score=-Inf, rejected, (best=107753.32997269552)
...
Iteration No.47 - final iterations - distance=NaN - welfare=0.0
Welfare = 0.0
```

## Root cause

The network-deepening step inside `annealing()` computes

```julia
I1 = (graph.delta_tau ./ graph.delta_i .* PQ) .^ (1 / (1 + param.gamma))
I1[graph.adjacency .== 0] .= 0
# I1[PQ .== 0] .= 0            # <-- commented out
# I1[graph.delta_i .== 0] .= 0 # <-- commented out
I1 *= param.K / sum(graph.delta_i .* I1)
```

On an edge with `delta_i == 0` (zero building cost), `delta_tau ./ delta_i` is `Inf`, so `I1` is `Inf` there. That entry survives the `adjacency == 0` mask (it is a real edge), and then `sum(graph.delta_i .* I1)` contains `0 * Inf = NaN`. The rescale `I1 *= K / NaN` multiplies `NaN` across the **entire** `I1` matrix — turning all J² entries to `NaN`, which feeds the next allocation solve and makes it fail with `-13`.

`optimal_network()`'s own FOC step already guards against exactly this (`src/main/optimal_network.jl`):

```julia
I1[graph.adjacency .== 0] .= 0
I1[PQ .== 0] .= 0
I1[graph.delta_i .== 0] .= 0
```

The two deepening blocks in `annealing.jl` had those two guard lines commented out — which is why the main loop is fine but annealing dies. (The reference MATLAB `annealing.m` omits the guards too, but it also never had zero-`delta_i` edges in the shipped examples.)

## Fix

Restore the two guard lines in both deepening blocks of `annealing.jl`, matching `optimal_network()`.

## Reproduction / validation

The CEMAC network has **10 edges already at ≥90 km/h with `delta_i = 0`** (`data/CEMAC/generate_cemac.jl` sets `delta_i = 0` for edges where `Iu ≈ Ijk`). Evaluating the exact annealing deepening formula on a real CEMAC allocation:

| variant | `sum(delta_i .* I1)` | `I1` NaN count |
|---|---|---|
| current (`annealing.jl`, no guards) | `NaN` | **38416 / 38416** |
| with the guards (this PR) | `10964.9` (finite) | **0 / 38416** |

End-to-end, annealing on CEMAC no longer prints `I1 has ... missing` and proceeds normally instead of cascading to `welfare = 0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)